### PR TITLE
Add Jenkins job for deploying hunter

### DIFF
--- a/maybelle/jobs/deploy-hunter.groovy
+++ b/maybelle/jobs/deploy-hunter.groovy
@@ -1,0 +1,27 @@
+pipelineJob('deploy-hunter') {
+    definition {
+        cps {
+            script('''
+                pipeline {
+                    agent any
+
+                    stages {
+                        stage('Deploy to hunter') {
+                            steps {
+                                sh """
+                                    ssh root@hunter.cryptograss.live '
+                                        cd /root/maybelle-config &&
+                                        git pull origin main &&
+                                        cd hunter &&
+                                        ./deploy.sh --do-not-copy-database
+                                    '
+                                """
+                            }
+                        }
+                    }
+                }
+            '''.stripIndent())
+            sandbox()
+        }
+    }
+}


### PR DESCRIPTION
Adds a Jenkins job that deploys hunter infrastructure from maybelle.

The job:
- SSHs to hunter VPS
- Pulls latest from maybelle-config repo
- Runs deployment script with plaintext vault already on hunter
- Skips database backup (not needed for infrastructure-only updates)

This allows triggering hunter deployments from Jenkins UI without exposing the vault password to Jenkins.