### PR TITLE
Add jq to maybelle apt packages

### DIFF
--- a/maybelle/ansible/maybelle.yml
+++ b/maybelle/ansible/maybelle.yml
@@ -36,6 +36,7 @@
           - docker-compose-v2
           - docker-buildx
           - ansible
+          - jq
         state: present
         update_cache: yes
 


### PR DESCRIPTION
Adds jq to the package list so the backup script can fetch Ethereum block heights for backup naming.