### PR TITLE
Add deploy marker system for secure NFS deployments

### DIFF
--- a/maybelle/ansible/maybelle.yml
+++ b/maybelle/ansible/maybelle.yml
@@ -107,6 +107,15 @@
         group: 1000
       notify: Restart Jenkins container
 
+    - name: Create log files for Jenkins to read
+      file:
+        path: "{{ item }}"
+        state: touch
+        mode: '0644'
+      loop:
+        - /var/log/nfs-backup.log
+        - /var/log/nfs-deploy.log
+
     - name: Start Jenkins container
       docker_container:
         name: jenkins
@@ -115,6 +124,8 @@
         volumes:
           - "{{ jenkins_home }}:/var/jenkins_home"
           - "/mnt/persist/magenta/backups:/mnt/persist/magenta/backups:ro"
+          - "/var/log/nfs-backup.log:/var/log/nfs-backup.log:ro"
+          - "/var/log/nfs-deploy.log:/var/log/nfs-deploy.log:ro"
           # Docker socket removed - Jenkins doesn't need it and it's a security risk
         env_file: "{{ jenkins_home }}/.env"
         env:

--- a/maybelle/jobs/backup-memory-lane.groovy
+++ b/maybelle/jobs/backup-memory-lane.groovy
@@ -80,6 +80,60 @@ pipelineJob('backup-memory-lane') {
                                 """
                             }
                         }
+
+                        stage('Check offsite backup status') {
+                            steps {
+                                sh """
+                                    DAILY_DIR="/mnt/persist/magenta/backups/daily"
+                                    OFFSITE_LOG="/var/log/nfs-backup.log"
+
+                                    echo ""
+                                    echo "=== Offsite Backup Status ==="
+
+                                    # Check daily backup directory
+                                    if [ ! -d "\\$DAILY_DIR" ]; then
+                                        echo "WARNING: Daily backup directory not found"
+                                    else
+                                        DAILY_COUNT=\\$(ls -1 "\\$DAILY_DIR"/*.dump 2>/dev/null | wc -l)
+                                        echo "Daily backups on disk: \\$DAILY_COUNT"
+
+                                        if [ "\\$DAILY_COUNT" -gt 0 ]; then
+                                            LATEST_DAILY=\\$(ls -t "\\$DAILY_DIR"/*.dump 2>/dev/null | head -1)
+                                            LATEST_DAILY_NAME=\\$(basename "\\$LATEST_DAILY")
+                                            LATEST_DAILY_AGE_DAYS=\\$(( (\\$(date +%s) - \\$(stat -c%Y "\\$LATEST_DAILY")) / 86400 ))
+                                            echo "Latest daily: \\$LATEST_DAILY_NAME (\\$LATEST_DAILY_AGE_DAYS days old)"
+                                        fi
+                                    fi
+
+                                    echo ""
+                                    echo "=== Offsite Sync Log ==="
+                                    if [ -f "\\$OFFSITE_LOG" ]; then
+                                        tail -5 "\\$OFFSITE_LOG"
+
+                                        # Check if last sync was successful and recent
+                                        LAST_SUCCESS=\\$(grep "successful" "\\$OFFSITE_LOG" | tail -1)
+                                        if [ -n "\\$LAST_SUCCESS" ]; then
+                                            echo ""
+                                            echo "Last successful sync: \\$LAST_SUCCESS"
+                                        fi
+
+                                        # Fail if no successful sync in last 36 hours
+                                        LAST_SYNC_TIME=\\$(grep "Starting offsite" "\\$OFFSITE_LOG" | tail -1 | cut -d: -f1-3)
+                                        if [ -n "\\$LAST_SYNC_TIME" ]; then
+                                            # Parse the date and check age
+                                            LAST_SYNC_EPOCH=\\$(date -d "\\$LAST_SYNC_TIME" +%s 2>/dev/null || echo 0)
+                                            NOW_EPOCH=\\$(date +%s)
+                                            SYNC_AGE_HOURS=\\$(( (NOW_EPOCH - LAST_SYNC_EPOCH) / 3600 ))
+                                            if [ "\\$SYNC_AGE_HOURS" -gt 36 ]; then
+                                                echo "WARNING: Last offsite sync attempt was \\$SYNC_AGE_HOURS hours ago!"
+                                            fi
+                                        fi
+                                    else
+                                        echo "(no offsite sync log found - sync may not have run yet)"
+                                    fi
+                                """
+                            }
+                        }
                     }
 
                     post {


### PR DESCRIPTION
## Summary
Security improvement that separates Jenkins from direct production hosting access.

**Before:** Jenkins pushed directly to NearlyFreeSpeech after successful builds
**After:** Jenkins creates a marker file; root cron on maybelle does the actual push

## Changes
- New `/usr/local/bin/deploy-to-nfs.sh` script that:
  - Checks for `.deploy-ready` marker in production build directory
  - Only rsyncs if marker exists
  - Logs deployments to `/var/log/nfs-deploy.log`
  - Removes marker after successful deploy
- Cron job runs every 2 minutes to check for pending deploys
- Removes old direct rsync cron job

## Security Benefit
A compromised Jenkins (malicious PR, plugin vuln, stolen creds) can no longer push arbitrary code to production. An attacker would also need root on maybelle to complete the attack chain.

## Deployment Notes
After merging, also need to merge the corresponding Jenkinsfile change in cryptograss/arthel (PR pending).