### PR TITLE
Fetch both main and production branches in deploy-hunter.sh

### DIFF
--- a/maybelle/scripts/deploy-hunter.sh
+++ b/maybelle/scripts/deploy-hunter.sh
@@ -56,7 +56,7 @@ fi
 echo ""
 echo "Updating maybelle-config repository..."
 cd "$REPO_DIR"
-git fetch origin
+git fetch origin main production
 
 # Hard reset to production (handles force pushes/rebases)
 git checkout production 2>/dev/null || git checkout -b production origin/production


### PR DESCRIPTION
Shallow clone on maybelle only had production branch, so the main-vs-production check failed.