### PR TITLE
Fix .gitconfig mount conflict causing container boot-cycle

### DIFF
--- a/hunter/ansible/roles/user-instance/tasks/main.yml
+++ b/hunter/ansible/roles/user-instance/tasks/main.yml
@@ -69,9 +69,12 @@
     group: 1000
     mode: '0600'
 
-- name: Create git config for user
+- name: Create git config for user (in persistent home directory)
   copy:
-    dest: "{{ base_dir }}/{{ user.name }}/.gitconfig"
+    dest: "{{ base_dir }}/{{ user.name }}/home/.gitconfig"
+    owner: 1000
+    group: 1000
+    mode: '0644'
     content: |
       [user]
         name = {{ user.full_name }}

--- a/hunter/ansible/roles/user-instance/templates/docker-compose.yml.j2
+++ b/hunter/ansible/roles/user-instance/templates/docker-compose.yml.j2
@@ -17,9 +17,8 @@ services:
     volumes:
       # Mount entire home directory to persist workspace, .claude, bash history, etc
       - {{ base_dir }}/{{ user.name }}/home:/home/magent
-      # SSH keys and git config mounted separately (read-only for security)
+      # SSH keys mounted separately (read-only for security)
       - {{ base_dir }}/{{ user.name }}/.ssh:/home/magent/.ssh:ro
-      - {{ base_dir }}/{{ user.name }}/.gitconfig:/home/magent/.gitconfig:ro
       - /var/run/docker.sock:/var/run/docker.sock
     networks:
       - magenta-net


### PR DESCRIPTION
## Problem

Containers were boot-cycling with this error:
```
failed to run git: error: could not write config file /home/magent/.gitconfig: Device or resource busy
```

## Root Cause

The `.gitconfig` was bind-mounted read-only from the host into `/home/magent/.gitconfig`, but `gh auth setup-git` (in container_startup.py) needs to write to it to add the credential helper.

## Fix

- Remove the separate `.gitconfig` bind mount from the compose template
- Write `.gitconfig` directly into the persistent home directory (`/home/.gitconfig`) instead of a separate location
- Add proper ownership (1000:1000) and permissions (0644)

The home directory is already mounted at `/home/magent`, so the gitconfig will persist and be writable by the container.