### PR TITLE
Add pickipedia job to Jenkins CasC config

### DIFF
--- a/maybelle/ansible/maybelle.yml
+++ b/maybelle/ansible/maybelle.yml
@@ -1005,8 +1005,7 @@
               container_name: pinning-service
               environment:
                 - PORT=3001
-                - PINATA_API_KEY={{ pinata_api_key }}
-                - PINATA_SECRET_KEY={{ pinata_secret_key }}
+                - PINATA_JWT={{ pinata_jwt }}
                 - AUTHORIZED_WALLETS={{ pinning_authorized_wallets }}
                 - IPFS_API_URL=http://ipfs:5001
                 - STAGING_DIR=/staging

--- a/maybelle/pinning-service/README.md
+++ b/maybelle/pinning-service/README.md
@@ -67,13 +67,13 @@ Health check (no auth required).
 Add these to `secrets/vault.yml`:
 
 ```yaml
-# Pinata IPFS pinning service credentials
-# Get from https://app.pinata.cloud/keys
-pinata_api_key: "your-pinata-api-key"
-pinata_secret_key: "your-pinata-secret-api-key"
+# Pinata IPFS pinning service JWT
+# Get from https://app.pinata.cloud/keys - create an API key with "write files" permission
+pinata_jwt: "your-pinata-jwt-token"
 
 # Comma-separated list of wallet addresses authorized to use the pinning service
 # Typically the Blue Railroad contract owner
+# IMPORTANT: Must be quoted as a string to preserve hex format
 pinning_authorized_wallets: "0x4f84b3650dbf651732a41647618e7ff94a633f09"
 ```
 


### PR DESCRIPTION
## Summary
- Add pickipedia.groovy to the jobs list in jenkins.yml CasC config

The groovy file was already deployed to `/var/jenkins_home/jobs/` but Jenkins wasn't loading it because it wasn't listed in the Configuration as Code jobs section.

## Test plan
- Merge and redeploy maybelle
- Verify pickipedia job appears in Jenkins UI