### PR TITLE
Add pause flag for pickipedia deploys

### DIFF
--- a/maybelle/ansible/maybelle.yml
+++ b/maybelle/ansible/maybelle.yml
@@ -324,7 +324,7 @@
           # Only deploys if Jenkins has marked a successful build
 
           MARKER_FILE="/var/jenkins_home/pickipedia_stage/.deploy-ready"
-          PAUSE_FILE="/var/jenkins_home/pickipedia_stage/.deploy-paused"
+          PAUSE_FILE="/var/jenkins_home/.pickipedia-deploy-paused"
           BUILD_DIR="/var/jenkins_home/pickipedia_stage"
           LOG_FILE="/var/log/pickipedia-deploy.log"
           NFS_TARGET="nfs-pickipedia:"


### PR DESCRIPTION
## Summary
- Adds `.deploy-paused` marker file check to pickipedia deploy script
- Deploy cron will skip rsync if pause file exists and log the reason

## Usage
To pause deploys:
```bash
echo "debugging 500 errors" > /var/jenkins_home/pickipedia_stage/.deploy-paused
```

To unpause:
```bash
rm /var/jenkins_home/pickipedia_stage/.deploy-paused
```

## Context
Needed for debugging production issues without rsync overwriting LocalSettings.local.php changes.