### PR TITLE
Add investigation stage to pickipedia-rsync-status job

### DIFF
--- a/maybelle/jobs/pickipedia-rsync-status.groovy
+++ b/maybelle/jobs/pickipedia-rsync-status.groovy
@@ -208,7 +208,7 @@ pipelineJob('pickipedia-rsync-status') {
                                         tail -30 "\\$DEPLOY_LOG"
                                         echo ""
                                         echo "=== Recent Errors in Log ==="
-                                        grep -i "error\\|fail\\|denied\\|refused\\|timeout\\|paused" "\\$DEPLOY_LOG" | tail -10 || echo "(no errors found)"
+                                        grep -iE "error|fail|denied|refused|timeout|paused" "\\$DEPLOY_LOG" | tail -10 || echo "(no errors found)"
                                     else
                                         echo "*** DEPLOY LOG MISSING: \\$DEPLOY_LOG ***"
                                     fi


### PR DESCRIPTION
## Summary
- When deploy is stale (>10 min since last success), runs investigation stage
- Checks if deploys are paused via pause file
- Checks deploy marker age and status  
- Verifies deploy script exists
- Shows last 30 lines of deploy log with highlighted errors
- Refactored to continue through all stages before failing (so we always see staging info)

## Context
Pickipedia deploys have been stale since Dec 29 (~2800 minutes). Currently the job just fails with "deploy is stale" but doesn't tell us WHY. This adds diagnostics.

## Test plan
- [ ] Merge and run Ansible playbook on maybelle
- [ ] Wait for next rsync-status run (every 5 min)
- [ ] Check console output for investigation details