### PR TITLE
Make pinning idempotent by computing CID and checking if it exists

### DIFF
--- a/maybelle/pinning-service/package.json
+++ b/maybelle/pinning-service/package.json
@@ -11,9 +11,10 @@
   "dependencies": {
     "cors": "^2.8.5",
     "express": "^4.18.2",
+    "form-data": "^4.0.0",
+    "ipfs-only-hash": "^4.0.0",
     "multer": "^1.4.5-lts.1",
     "node-fetch": "^3.3.2",
-    "form-data": "^4.0.0",
     "viem": "^2.0.0"
   },
   "devDependencies": {


### PR DESCRIPTION
## Summary
- Computes CID from file content before uploading using `ipfs-only-hash`
- Checks if CID already exists on Pinata gateway
- Skips upload if content is already pinned, returns `{ cid: '...', alreadyPinned: true }`

This makes the pin endpoint idempotent - clicking "Pin to IPFS" multiple times (or after page refresh) returns the same CID without re-uploading. The CID is derived purely from file content, so it works across browsers/users.

## Files Changed
- `maybelle/pinning-service/server.js` - Added CID computation and existence check
- `maybelle/pinning-service/package.json` - Added `ipfs-only-hash` dependency

## Deployment Note
Requires `--build` flag on docker compose since we added a new npm dependency.