### PR TITLE
Add --delay-updates to pickipedia rsync for atomic deploys

### DIFF
--- a/maybelle/ansible/maybelle.yml
+++ b/maybelle/ansible/maybelle.yml
@@ -353,10 +353,11 @@
 
           # Perform the rsync
           # --chmod ensures files are world-readable on NFS
+          # --delay-updates stages files in temp location, then moves at end (more atomic)
           # Exclude images/ so uploads persist and remain writable
           # Exclude stats/ for GoAccess-generated analytics reports
           # Exclude .git directories - no need for version control metadata in prod
-          if rsync -vah --delete \
+          if rsync -vah --delete --delay-updates \
               --chmod=F644,D755 \
               --exclude='.deploy-ready' \
               --exclude='images/' \


### PR DESCRIPTION
## Summary
Adds `--delay-updates` flag to the pickipedia rsync deploy.

This stages all file updates in a temp location on the remote, then moves them into place at the end. Makes deploys more atomic - old files stay in place until rsync is almost done, then everything swaps quickly.

Reduces the window where partial transfers can cause 500 errors.