### PR TITLE
Add 14-day retention limit to GlitchTip

### DIFF
--- a/maybelle/ansible/maybelle.yml
+++ b/maybelle/ansible/maybelle.yml
@@ -931,6 +931,7 @@
                 DEFAULT_FROM_EMAIL: glitchtip@cryptograss.live
                 EMAIL_URL: "consolemail://"
                 ENABLE_OPEN_USER_REGISTRATION: "True"
+                GLITCHTIP_MAX_EVENT_LIFE_DAYS: "14"
               networks:
                 - glitchtip-net
               restart: unless-stopped
@@ -947,6 +948,7 @@
                 REDIS_URL: redis://redis:6379/0
                 SECRET_KEY: {{ glitchtip_secret_key }}
                 GLITCHTIP_DOMAIN: https://glitchtip.maybelle.cryptograss.live
+                GLITCHTIP_MAX_EVENT_LIFE_DAYS: "14"
               networks:
                 - glitchtip-net
               restart: unless-stopped


### PR DESCRIPTION
## Summary
- Add `GLITCHTIP_MAX_EVENT_LIFE_DAYS: "14"` to both web and worker services
- Prevents disk bloat from GlitchTip's default 90-day retention

## Problem
GlitchTip accumulated 3.4GB of postgres data on the persistent volume, causing disk space issues that broke the MCP server for magenta-memory.

## Test plan
- [ ] Merge and redeploy maybelle
- [ ] Manually clear `/mnt/persist/glitchtip/postgres-data/*` on maybelle before restart
- [ ] Verify GlitchTip restarts cleanly
- [ ] Verify MCP server works after disk space freed