### PR TITLE
Add pip upgrade step to blue railroad import job

### DIFF
--- a/maybelle/jobs/arthel-fetch-chain-data.groovy
+++ b/maybelle/jobs/arthel-fetch-chain-data.groovy
@@ -1,4 +1,7 @@
 pipelineJob('arthel-fetch-chain-data') {
+    properties {
+        disableConcurrentBuilds()
+    }
     definition {
         cpsScm {
             scm {

--- a/maybelle/jobs/arthel-production-build.groovy
+++ b/maybelle/jobs/arthel-production-build.groovy
@@ -1,4 +1,7 @@
 pipelineJob('arthel-production-build') {
+    properties {
+        disableConcurrentBuilds()
+    }
     definition {
         cpsScm {
             scm {

--- a/maybelle/jobs/arthel-rsync-status.groovy
+++ b/maybelle/jobs/arthel-rsync-status.groovy
@@ -6,6 +6,10 @@ pipelineJob('arthel-rsync-status') {
                 pipeline {
                     agent any
 
+                    options {
+                        disableConcurrentBuilds()
+                    }
+
                     stages {
                         stage('Check deploy marker') {
                             steps {

--- a/maybelle/jobs/pickipedia-build.groovy
+++ b/maybelle/jobs/pickipedia-build.groovy
@@ -1,4 +1,7 @@
 pipelineJob('pickipedia-build') {
+    properties {
+        disableConcurrentBuilds()
+    }
     definition {
         cpsScm {
             scm {

--- a/maybelle/jobs/pickipedia-import-bluerailroad.groovy
+++ b/maybelle/jobs/pickipedia-import-bluerailroad.groovy
@@ -8,6 +8,7 @@ pipelineJob('pickipedia-import-bluerailroad') {
                     agent any
 
                     options {
+                        disableConcurrentBuilds()
                         buildDiscarder(logRotator(numToKeepStr: '30'))
                         timeout(time: 5, unit: 'MINUTES')
                     }

--- a/maybelle/jobs/pickipedia-rsync-status.groovy
+++ b/maybelle/jobs/pickipedia-rsync-status.groovy
@@ -6,6 +6,10 @@ pipelineJob('pickipedia-rsync-status') {
                 pipeline {
                     agent any
 
+                    options {
+                        disableConcurrentBuilds()
+                    }
+
                     environment {
                         DEPLOY_STALE = 'false'
                         STALE_MINUTES = '0'

--- a/maybelle/jobs/pickipedia-uptime.groovy
+++ b/maybelle/jobs/pickipedia-uptime.groovy
@@ -6,6 +6,10 @@ pipelineJob('pickipedia-uptime') {
                 pipeline {
                     agent any
 
+                    options {
+                        disableConcurrentBuilds()
+                    }
+
                     environment {
                         FAILURE_COUNT_FILE = '/var/jenkins_home/pickipedia-uptime-failures.txt'
                         ALERT_THRESHOLD = '2'


### PR DESCRIPTION
Ensures the latest version of blue-railroad-import is used on each run, without requiring a Docker image rebuild.