### PR TITLE
Add PickiPedia VPS ansible infrastructure

### DIFF
--- a/maybelle/scripts/deploy-pickipedia.sh
+++ b/maybelle/scripts/deploy-pickipedia.sh
@@ -1,0 +1,194 @@
+#!/bin/bash
+#
+# Deploy PickiPedia VPS from maybelle
+# This script runs ON maybelle and handles the full deploy + Jenkins reporting
+#
+# The vault password is passed via stdin from the caller's laptop.
+# The Jenkins reporter password is read from /root/.jenkins_reporter_password
+#
+# Usage from laptop:
+#   echo "$ANSIBLE_VAULT_PASSWORD" | ssh root@maybelle.cryptograss.live /mnt/persist/maybelle-config/maybelle/scripts/deploy-pickipedia.sh [--fresh-host]
+#
+
+set -o pipefail
+# Note: NOT using 'set -e' because we want to handle errors explicitly
+
+FRESH_HOST=false
+REPO_DIR="/mnt/persist/maybelle-config"
+JENKINS_REPORTER_FILE="/root/.jenkins_reporter_password"
+TIMESTAMP=$(date +%Y%m%d-%H%M%S)
+LOG_FILE="/mnt/persist/logs/pickipedia-deploy-${TIMESTAMP}.log"
+VAULT_FILE="/tmp/vault_pass_$$"
+PICKIPEDIA_HOST="89.167.16.89"
+
+# Parse arguments
+if [ "$1" = "--fresh-host" ]; then
+    FRESH_HOST=true
+fi
+
+echo "============================================================"
+echo "DEPLOY PICKIPEDIA VPS FROM MAYBELLE"
+if [ "$FRESH_HOST" = true ]; then
+    echo "(FRESH HOST - will reset SSH keys)"
+fi
+echo "============================================================"
+echo ""
+
+# Read vault password from stdin
+echo "Reading vault password from stdin..."
+read -r VAULT_PASSWORD
+if [ -z "$VAULT_PASSWORD" ]; then
+    echo "ERROR: No vault password provided on stdin"
+    exit 1
+fi
+
+# Write to temp file
+echo "$VAULT_PASSWORD" > "$VAULT_FILE"
+chmod 600 "$VAULT_FILE"
+echo "✓ Vault password received"
+
+# Ensure log directory exists
+mkdir -p /mnt/persist/logs
+
+# Cleanup function (keep logs, only remove vault file)
+cleanup() {
+    rm -f "$VAULT_FILE"
+}
+trap cleanup EXIT
+
+# Get Jenkins reporter password
+if [ -f "$JENKINS_REPORTER_FILE" ]; then
+    REPORTER_PASS=$(cat "$JENKINS_REPORTER_FILE")
+else
+    echo "⚠ No Jenkins reporter password found, will skip reporting"
+    REPORTER_PASS=""
+fi
+
+# Update repository
+echo ""
+echo "Updating maybelle-config repository..."
+cd "$REPO_DIR"
+
+# Ensure we can fetch all branches (fixes shallow single-branch clones)
+git remote set-branches origin '*'
+git fetch origin main production
+
+# Hard reset to production (handles force pushes/rebases)
+git checkout production 2>/dev/null || git checkout -b production origin/production
+git reset --hard origin/production
+
+# Check that production is not behind main
+if ! git merge-base --is-ancestor origin/main origin/production; then
+    echo "ERROR: production branch is behind main"
+    echo "Please update production to include latest main changes"
+    exit 1
+fi
+echo "✓ Repository updated"
+
+# Handle fresh host SSH keys
+if [ "$FRESH_HOST" = true ]; then
+    echo ""
+    echo "============================================================"
+    echo "HANDLING FRESH HOST SSH KEYS"
+    echo "============================================================"
+    echo ""
+
+    echo "Removing old SSH host keys for $PICKIPEDIA_HOST..."
+    ssh-keygen -R "$PICKIPEDIA_HOST" 2>/dev/null || true
+    echo "✓ Old host keys removed"
+
+    echo ""
+    echo "Fetching new SSH host key..."
+    ssh-keyscan -H "$PICKIPEDIA_HOST" >> ~/.ssh/known_hosts 2>/dev/null
+    echo "✓ New host key added to known_hosts"
+fi
+
+# Run ansible
+echo ""
+echo "============================================================"
+echo "RUNNING ANSIBLE PLAYBOOK"
+echo "============================================================"
+echo ""
+
+START_TIME=$(date +%s)
+
+cd "$REPO_DIR/pickipedia-vps/ansible"
+
+# Run ansible playbook
+ANSIBLE_CMD="ansible-playbook --vault-password-file=\"$VAULT_FILE\" -i inventory.yml playbook.yml"
+
+if bash -c "$ANSIBLE_CMD" 2>&1 | tee "$LOG_FILE"; then
+    DEPLOY_STATUS="success"
+    EXIT_CODE=0
+    echo ""
+    echo "✓ Deployment complete"
+else
+    DEPLOY_STATUS="failure"
+    EXIT_CODE=1
+    echo ""
+    echo "✗ Deployment failed"
+fi
+
+END_TIME=$(date +%s)
+DURATION=$((END_TIME - START_TIME))
+
+echo ""
+echo "============================================================"
+
+# Report to Jenkins (optional - can add deploy-pickipedia job later)
+if [ -n "$REPORTER_PASS" ]; then
+    echo "Reporting to Jenkins..."
+
+    # Read log, truncate if huge
+    LOG_CONTENT=$(tail -c 50000 "$LOG_FILE" 2>/dev/null || echo "(no log)")
+
+    COOKIE_JAR="/tmp/jenkins_cookies_$$"
+
+    # Get CSRF crumb (and session cookie - crumb is tied to session)
+    CRUMB=$(curl -s -c "$COOKIE_JAR" -u "reporter:$REPORTER_PASS" \
+        "http://localhost:8080/crumbIssuer/api/json" \
+        | python3 -c "import sys,json; print(json.load(sys.stdin)['crumb'])" 2>/dev/null)
+
+    if [ -z "$CRUMB" ]; then
+        echo "⚠ Could not get Jenkins crumb"
+    else
+        # Try to report to deploy-pickipedia-vps job (may not exist yet)
+        HTTP_CODE=$(curl -s -o /dev/null -w "%{http_code}" \
+            -b "$COOKIE_JAR" \
+            -X POST \
+            -u "reporter:$REPORTER_PASS" \
+            -H "Jenkins-Crumb: $CRUMB" \
+            --data-urlencode "DEPLOY_STATUS=$DEPLOY_STATUS" \
+            --data-urlencode "DEPLOY_DURATION=$DURATION" \
+            --data-urlencode "DEPLOY_LOG=$LOG_CONTENT" \
+            "http://localhost:8080/job/deploy-pickipedia-vps/buildWithParameters" \
+            2>/dev/null || echo "000")
+
+        if [ "$HTTP_CODE" = "201" ] || [ "$HTTP_CODE" = "200" ]; then
+            echo "✓ Reported to Jenkins"
+        elif [ "$HTTP_CODE" = "404" ]; then
+            echo "⚠ Jenkins job 'deploy-pickipedia-vps' not found (skipping)"
+        else
+            echo "⚠ Could not report to Jenkins (HTTP $HTTP_CODE)"
+        fi
+    fi
+
+    rm -f "$COOKIE_JAR"
+fi
+
+echo ""
+echo "Full deployment log saved to: $LOG_FILE"
+echo ""
+if [ $EXIT_CODE -eq 0 ]; then
+    echo "✓ SUCCESS"
+    echo ""
+    echo "Next steps:"
+    echo "  1. SSH to the new server: ssh root@$PICKIPEDIA_HOST"
+    echo "  2. Run the import script: /usr/local/bin/import-pickipedia-backup.sh"
+    echo "  3. Configure secrets in LocalSettings.local.php"
+    echo "  4. Update DNS for pickipedia.xyz"
+else
+    echo "✗ FAILED"
+fi
+
+exit $EXIT_CODE

--- a/pickipedia-vps/README.md
+++ b/pickipedia-vps/README.md
@@ -1,0 +1,145 @@
+# PickiPedia VPS Migration
+
+Infrastructure for migrating PickiPedia from NearlyFreeSpeech to a dedicated Hetzner VPS.
+
+## Background
+
+PickiPedia was hosted on NearlyFreeSpeech shared hosting, which hit connection limits during a large video upload, causing complete PHP failure. Rather than troubleshoot NFSN's shared environment, we're migrating to our own VPS for full control.
+
+## Recommended Server
+
+**Hetzner CX32** (~€8/month)
+- 4 vCPU (AMD EPYC)
+- 8 GB RAM
+- 80 GB NVMe SSD
+- Location: Falkenstein or Nuremberg (network locality with hunter/maybelle)
+
+## Stack
+
+- **OS**: Ubuntu 24.04 LTS
+- **Web Server**: Nginx + Caddy (SSL termination)
+- **PHP**: PHP-FPM 8.2
+- **Database**: MariaDB 10.11 LTS
+- **SSL**: Let's Encrypt via Caddy (automatic)
+
+## Prerequisites
+
+1. **Order Hetzner VPS**
+   - Go to https://console.hetzner.cloud
+   - Create CX32 server with Ubuntu 24.04
+   - Add your SSH key during creation
+   - Note the IP address
+
+2. **Update DNS**
+   - Create `pickipedia.cryptograss.live` A record pointing to new server IP
+   - Keep `pickipedia.xyz` pointing to NFSN until ready to switch
+
+3. **Add SSH key to new server**
+   - The deploy script runs from maybelle, so maybelle needs SSH access
+   - Add maybelle's root SSH key to the new server's authorized_keys
+
+## Deployment
+
+Deployment runs FROM maybelle (same pattern as hunter):
+
+```bash
+# From your laptop - pipe vault password to deploy script
+echo "$ANSIBLE_VAULT_PASSWORD" | ssh root@maybelle.cryptograss.live \
+    /mnt/persist/maybelle-config/maybelle/scripts/deploy-pickipedia.sh --fresh-host
+```
+
+The `--fresh-host` flag handles SSH host key setup for the new server.
+
+## Post-Deployment Migration
+
+After the playbook completes, SSH to the new server and run the migration:
+
+```bash
+ssh root@pickipedia.cryptograss.live
+
+# Run the import script
+/usr/local/bin/import-pickipedia-backup.sh
+
+# Create LocalSettings.local.php with secrets
+cp /var/www/pickipedia/LocalSettings.local.php.template /var/www/pickipedia/LocalSettings.local.php
+vim /var/www/pickipedia/LocalSettings.local.php
+# Fill in: $wgDBpassword, $wgSecretKey, $wgUpgradeKey
+# Get these values from the vault or the current NFSN installation
+```
+
+## DNS Cutover
+
+Once the new server is verified working:
+
+1. Update `pickipedia.xyz` A record to point to new server IP
+2. Update `www.pickipedia.xyz` CNAME or A record
+3. Wait for DNS propagation (usually 5-30 minutes)
+4. Update maybelle's Jenkins jobs to deploy to new server instead of NFSN
+
+## Files
+
+```
+pickipedia-vps/
+├── README.md                 # This file
+└── ansible/
+    ├── inventory.yml         # Server config
+    ├── playbook.yml          # Main playbook
+    └── roles/
+        ├── mariadb/          # Database
+        ├── php-fpm/          # PHP processing
+        ├── nginx/            # Local web server
+        ├── caddy/            # SSL termination
+        └── mediawiki/        # Wiki application
+```
+
+## Backup Sources
+
+Backups are pulled from maybelle:
+- **Database**: `/mnt/persist/pickipedia/backups/pickipedia_YYYYMMDD.sql.gz`
+- **Images**: `/mnt/persist/pickipedia/backups/images/`
+
+Daily backups run at 3:30 AM via the `backup-pickipedia` Jenkins job.
+
+## Monitoring
+
+After migration, update the `pickipedia-uptime` Jenkins job to point at the new server. The health check endpoint is available at:
+
+```
+https://pickipedia.xyz/wiki/Main_Page  # Main page check
+http://[server-ip]:8081/health          # Caddy health endpoint
+```
+
+## Rolling Back
+
+If migration fails, simply point DNS back to NFSN. The old installation will still be there (though possibly still having the connection issues that prompted this migration).
+
+## Future Jenkins Integration
+
+The `pickipedia-build` and `pickipedia-rsync-status` jobs will need updating to deploy to the new server instead of NFSN. This involves:
+
+1. Adding SSH key for new server to maybelle
+2. Updating deploy script target in `deploy-pickipedia-to-nfs.sh`
+3. Testing rsync deployment
+
+This is a separate task from the migration itself.
+
+## Quick Reference
+
+```bash
+# Initial deployment (from laptop)
+echo "$ANSIBLE_VAULT_PASSWORD" | ssh root@maybelle.cryptograss.live \
+    /mnt/persist/maybelle-config/maybelle/scripts/deploy-pickipedia.sh --fresh-host
+
+# Subsequent deploys (no --fresh-host needed)
+echo "$ANSIBLE_VAULT_PASSWORD" | ssh root@maybelle.cryptograss.live \
+    /mnt/persist/maybelle-config/maybelle/scripts/deploy-pickipedia.sh
+
+# SSH to new server
+ssh root@pickipedia.cryptograss.live
+
+# Run migration import
+/usr/local/bin/import-pickipedia-backup.sh
+
+# Check services
+systemctl status nginx php8.2-fpm mariadb caddy
+```

--- a/pickipedia-vps/ansible/inventory.yml
+++ b/pickipedia-vps/ansible/inventory.yml
@@ -1,0 +1,34 @@
+all:
+  hosts:
+    pickipedia:  # After picking, a picking encyclopedia
+      ansible_host: 89.167.16.89
+      ansible_user: root
+  vars:
+    # Server specs (Hetzner CX32 recommended)
+    # - 4 vCPU (AMD EPYC)
+    # - 8 GB RAM
+    # - 80 GB NVMe
+    # - ~€8/month
+
+    # Domain and SSL
+    domain_name: pickipedia.xyz
+    www_domain: www.pickipedia.xyz
+
+    # MediaWiki version
+    mediawiki_version: "1.43.6"
+
+    # Database
+    mariadb_version: "10.11"
+    db_name: pickipedia
+    db_user: wiki
+
+    # PHP version (MediaWiki 1.43 requires PHP 8.1+)
+    php_version: "8.2"
+
+    # Server paths
+    web_root: /var/www/pickipedia
+    mediawiki_root: /var/www/pickipedia
+
+    # Backup sources (on maybelle)
+    backup_host: maybelle.cryptograss.live
+    backup_path: /mnt/persist/pickipedia/backups

--- a/pickipedia-vps/ansible/playbook.yml
+++ b/pickipedia-vps/ansible/playbook.yml
@@ -1,0 +1,96 @@
+---
+# PickiPedia VPS Provisioning Playbook
+# MediaWiki wiki on dedicated Hetzner VPS
+#
+# Pre-requisites:
+# 1. Create Hetzner CX32 VPS with Ubuntu 24.04
+# 2. Add SSH key during creation
+# 3. Point pickipedia.xyz A record to new server IP
+# 4. Run: ansible-playbook -i inventory.yml playbook.yml
+#
+# Migration steps:
+# 1. Run this playbook (creates empty MediaWiki)
+# 2. Import database from backup
+# 3. Import images from backup
+# 4. Update LocalSettings.php with production secrets
+# 5. Switch DNS to new server
+
+- name: Provision PickiPedia MediaWiki Server
+  hosts: pickipedia
+  become: yes
+
+  vars_files:
+    - ../../secrets/vault.yml  # Relative to pickipedia-vps/ansible/
+
+  vars:
+    # Packages needed for MediaWiki
+    system_packages:
+      - apt-transport-https
+      - ca-certificates
+      - curl
+      - software-properties-common
+      - git
+      - unzip
+      - imagemagick
+      - ffmpeg
+      - lua5.4
+      - liblua5.4-dev
+
+  pre_tasks:
+    - name: Update apt cache
+      apt:
+        update_cache: yes
+        cache_valid_time: 3600
+
+    - name: Install system packages
+      apt:
+        name: "{{ system_packages }}"
+        state: present
+
+    - name: Set timezone
+      timezone:
+        name: UTC
+
+    - name: Deploy SSH login banner
+      copy:
+        content: |
+
+           ____  _      _    _ ____           _ _
+          |  _ \(_) ___| | _(_)  _ \ ___  __| (_) __ _
+          | |_) | |/ __| |/ / | |_) / _ \/ _` | |/ _` |
+          |  __/| | (__|   <| |  __/  __/ (_| | | (_| |
+          |_|   |_|\___|_|\_\_|_|   \___|\__,_|_|\__,_|
+
+          MediaWiki Encyclopedia for Traditional Music
+          https://pickipedia.xyz
+
+        dest: /etc/motd
+        mode: '0644'
+
+  roles:
+    - mariadb
+    - php-fpm
+    - nginx
+    - caddy  # For SSL termination
+    - mediawiki
+
+  post_tasks:
+    - name: Display post-installation notes
+      debug:
+        msg: |
+          PickiPedia VPS provisioned successfully!
+
+          Next steps:
+          1. Import database:
+             scp maybelle:/mnt/persist/pickipedia/backups/pickipedia_latest.sql.gz /tmp/
+             gunzip -c /tmp/pickipedia_*.sql.gz | mysql -u wiki -p pickipedia
+
+          2. Import images:
+             rsync -avz maybelle:/mnt/persist/pickipedia/backups/images/ {{ mediawiki_root }}/images/
+
+          3. Update LocalSettings.php with production secrets
+
+          4. Run MediaWiki update:
+             cd {{ mediawiki_root }} && php maintenance/update.php
+
+          5. Update DNS A record for pickipedia.xyz to point to this server

--- a/pickipedia-vps/ansible/roles/caddy/handlers/main.yml
+++ b/pickipedia-vps/ansible/roles/caddy/handlers/main.yml
@@ -1,0 +1,5 @@
+---
+- name: Restart Caddy
+  systemd:
+    name: caddy
+    state: restarted

--- a/pickipedia-vps/ansible/roles/caddy/tasks/main.yml
+++ b/pickipedia-vps/ansible/roles/caddy/tasks/main.yml
@@ -1,0 +1,96 @@
+---
+# Caddy for automatic SSL and reverse proxy
+# Much simpler than certbot + nginx SSL config
+
+- name: Install Caddy dependencies
+  apt:
+    name:
+      - debian-keyring
+      - debian-archive-keyring
+      - apt-transport-https
+    state: present
+
+- name: Add Caddy GPG key
+  apt_key:
+    url: https://dl.cloudsmith.io/public/caddy/stable/gpg.key
+    state: present
+
+- name: Add Caddy repository
+  apt_repository:
+    repo: "deb https://dl.cloudsmith.io/public/caddy/stable/deb/debian any-version main"
+    state: present
+    filename: caddy-stable
+
+- name: Install Caddy
+  apt:
+    name: caddy
+    state: present
+    update_cache: yes
+
+- name: Create Caddyfile
+  copy:
+    dest: /etc/caddy/Caddyfile
+    content: |
+      # PickiPedia - SSL termination and reverse proxy
+      # Caddy automatically handles Let's Encrypt certificates
+
+      {{ domain_name }}, {{ www_domain }} {
+          # Reverse proxy to Nginx (which handles PHP-FPM)
+          reverse_proxy 127.0.0.1:8080
+
+          # Logging
+          log {
+              output file /var/log/caddy/pickipedia-access.log {
+                  roll_size 100mb
+                  roll_keep 5
+              }
+          }
+
+          # Security headers
+          header {
+              X-Content-Type-Options nosniff
+              X-Frame-Options SAMEORIGIN
+              Referrer-Policy strict-origin-when-cross-origin
+              # Remove server header
+              -Server
+          }
+
+          # Compression
+          encode gzip zstd
+
+          # Handle www redirect
+          @www host {{ www_domain }}
+          redir @www https://{{ domain_name }}{uri} permanent
+      }
+
+      # Health check endpoint (for monitoring from maybelle)
+      :8081 {
+          respond /health "OK" 200
+      }
+    mode: '0644'
+  notify: Restart Caddy
+
+- name: Create Caddy log directory
+  file:
+    path: /var/log/caddy
+    state: directory
+    owner: caddy
+    group: caddy
+    mode: '0755'
+
+- name: Start and enable Caddy
+  systemd:
+    name: caddy
+    state: started
+    enabled: yes
+
+- name: Wait for Caddy to obtain SSL certificate
+  uri:
+    url: "https://{{ domain_name }}/wiki/Main_Page"
+    status_code: [200, 302, 404]
+    validate_certs: yes
+  register: ssl_check
+  retries: 30
+  delay: 10
+  until: ssl_check.status in [200, 302, 404]
+  ignore_errors: yes

--- a/pickipedia-vps/ansible/roles/mariadb/handlers/main.yml
+++ b/pickipedia-vps/ansible/roles/mariadb/handlers/main.yml
@@ -1,0 +1,5 @@
+---
+- name: Restart MariaDB
+  systemd:
+    name: mariadb
+    state: restarted

--- a/pickipedia-vps/ansible/roles/mariadb/tasks/main.yml
+++ b/pickipedia-vps/ansible/roles/mariadb/tasks/main.yml
@@ -1,0 +1,84 @@
+---
+# MariaDB installation for PickiPedia
+# Uses MariaDB 10.11 LTS
+
+- name: Install MariaDB server
+  apt:
+    name:
+      - mariadb-server
+      - mariadb-client
+      - python3-pymysql
+    state: present
+
+- name: Start and enable MariaDB
+  systemd:
+    name: mariadb
+    state: started
+    enabled: yes
+
+- name: Create database
+  community.mysql.mysql_db:
+    name: "{{ db_name }}"
+    state: present
+    login_unix_socket: /var/run/mysqld/mysqld.sock
+
+- name: Create database user
+  community.mysql.mysql_user:
+    name: "{{ db_user }}"
+    password: "{{ pickipedia_db_password }}"
+    priv: "{{ db_name }}.*:ALL"
+    state: present
+    login_unix_socket: /var/run/mysqld/mysqld.sock
+
+- name: Configure MariaDB for MediaWiki
+  copy:
+    dest: /etc/mysql/mariadb.conf.d/99-mediawiki.cnf
+    content: |
+      [mysqld]
+      # MediaWiki recommended settings
+      innodb_buffer_pool_size = 1G
+      innodb_log_file_size = 256M
+      innodb_flush_log_at_trx_commit = 2
+      innodb_file_per_table = 1
+
+      # Character set
+      character-set-server = utf8mb4
+      collation-server = utf8mb4_unicode_ci
+
+      # Performance
+      max_connections = 100
+      query_cache_type = 0
+      query_cache_size = 0
+
+      # Binary logging for backup (optional)
+      # log_bin = /var/log/mysql/mysql-bin.log
+      # expire_logs_days = 7
+    mode: '0644'
+  notify: Restart MariaDB
+
+- name: Create backup script
+  copy:
+    dest: /usr/local/bin/backup-pickipedia-db.sh
+    mode: '0750'
+    content: |
+      #!/bin/bash
+      # Daily database backup
+      BACKUP_DIR="/var/backups/pickipedia"
+      mkdir -p "$BACKUP_DIR"
+
+      DATE=$(date +%Y%m%d)
+      BACKUP_FILE="$BACKUP_DIR/pickipedia_${DATE}.sql.gz"
+
+      mysqldump --single-transaction pickipedia | gzip > "$BACKUP_FILE"
+
+      # Keep last 14 days
+      find "$BACKUP_DIR" -name "pickipedia_*.sql.gz" -mtime +14 -delete
+
+      echo "$(date): Backup completed: $BACKUP_FILE ($(stat -c%s "$BACKUP_FILE") bytes)" >> /var/log/pickipedia-backup.log
+
+- name: Schedule daily backup
+  ansible.builtin.cron:
+    name: "pickipedia database backup"
+    hour: "3"
+    minute: "0"
+    job: "/usr/local/bin/backup-pickipedia-db.sh"

--- a/pickipedia-vps/ansible/roles/mediawiki/tasks/main.yml
+++ b/pickipedia-vps/ansible/roles/mediawiki/tasks/main.yml
@@ -1,0 +1,284 @@
+---
+# MediaWiki installation and configuration
+# Downloads MediaWiki, installs composer dependencies, configures for migration
+
+- name: Create web root directory
+  file:
+    path: "{{ mediawiki_root }}"
+    state: directory
+    owner: www-data
+    group: www-data
+    mode: '0755'
+
+- name: Download MediaWiki
+  get_url:
+    url: "https://releases.wikimedia.org/mediawiki/1.43/mediawiki-{{ mediawiki_version }}.tar.gz"
+    dest: /tmp/mediawiki-{{ mediawiki_version }}.tar.gz
+    mode: '0644'
+  register: mediawiki_download
+
+- name: Extract MediaWiki
+  unarchive:
+    src: /tmp/mediawiki-{{ mediawiki_version }}.tar.gz
+    dest: "{{ mediawiki_root }}"
+    remote_src: yes
+    extra_opts:
+      - --strip-components=1
+    owner: www-data
+    group: www-data
+  when: mediawiki_download.changed
+
+- name: Install Composer
+  get_url:
+    url: https://getcomposer.org/download/latest-stable/composer.phar
+    dest: /usr/local/bin/composer
+    mode: '0755'
+
+- name: Create images directory
+  file:
+    path: "{{ mediawiki_root }}/images"
+    state: directory
+    owner: www-data
+    group: www-data
+    mode: '0755'
+
+- name: Create cache directory
+  file:
+    path: "{{ mediawiki_root }}/cache"
+    state: directory
+    owner: www-data
+    group: www-data
+    mode: '0755'
+
+# Base LocalSettings.php - will need to be updated with secrets after migration
+- name: Create base LocalSettings.php
+  copy:
+    dest: "{{ mediawiki_root }}/LocalSettings.php"
+    content: |
+      <?php
+      # PickiPedia MediaWiki Configuration
+      # Base configuration - secrets loaded from LocalSettings.local.php
+
+      # Protect against web entry
+      if ( !defined( 'MEDIAWIKI' ) ) {
+          exit;
+      }
+
+      ## Site basics
+      $wgSitename = "PickiPedia";
+      $wgMetaNamespace = "PickiPedia";
+
+      ## The URL base path to the directory containing the wiki
+      $wgScriptPath = "";
+      $wgArticlePath = "/wiki/$1";
+      $wgUsePathInfo = true;
+
+      ## Server URLs
+      $wgServer = "https://{{ domain_name }}";
+
+      ## Resource paths
+      $wgResourceBasePath = $wgScriptPath;
+
+      ## Logo
+      $wgLogos = [
+          '1x' => "$wgResourceBasePath/resources/assets/pickipedia.png",
+          'icon' => "$wgResourceBasePath/resources/assets/pickipedia.png",
+      ];
+
+      ## Contact info
+      $wgEmergencyContact = "justin@cryptograss.live";
+      $wgPasswordSender = "wiki@pickipedia.xyz";
+
+      ## Database settings
+      # Loaded from LocalSettings.local.php
+
+      ## Shared memory settings
+      $wgMainCacheType = CACHE_ACCEL;
+      $wgMemCachedServers = [];
+
+      ## File uploads
+      $wgEnableUploads = true;
+      $wgUseImageMagick = true;
+      $wgImageMagickConvertCommand = "/usr/bin/convert";
+      $wgMaxUploadSize = 104857600; # 100MB
+      $wgFileExtensions = array_merge(
+          $wgFileExtensions,
+          [ 'pdf', 'mp3', 'mp4', 'ogg', 'webm', 'svg' ]
+      );
+
+      ## InstantCommons allows wiki to use images from commons.wikimedia.org
+      $wgUseInstantCommons = true;
+
+      ## Skin
+      $wgDefaultSkin = "timeless";
+      wfLoadSkin( 'Timeless' );
+      wfLoadSkin( 'Vector' );
+      wfLoadSkin( 'MinervaNeue' );
+
+      ## License
+      $wgRightsPage = "";
+      $wgRightsUrl = "https://creativecommons.org/licenses/by-sa/4.0/";
+      $wgRightsText = "Creative Commons Attribution-ShareAlike";
+      $wgRightsIcon = "$wgResourceBasePath/resources/assets/licenses/cc-by-sa.png";
+
+      ## Path to the GNU diff3 utility
+      $wgDiff3 = "/usr/bin/diff3";
+
+      ## Jobs
+      $wgJobRunRate = 0; # Disable job queue on web requests
+      # Run jobs via cron instead
+
+      ## Caching
+      $wgCacheDirectory = "$IP/cache";
+
+      ## Email
+      $wgEnableEmail = true;
+      $wgEnableUserEmail = true;
+      $wgEmailAuthentication = true;
+
+      ## Namespaces
+      define("NS_MUSICIAN", 100);
+      define("NS_MUSICIAN_TALK", 101);
+      define("NS_SHOW", 102);
+      define("NS_SHOW_TALK", 103);
+      $wgExtraNamespaces[NS_MUSICIAN] = "Musician";
+      $wgExtraNamespaces[NS_MUSICIAN_TALK] = "Musician_talk";
+      $wgExtraNamespaces[NS_SHOW] = "Show";
+      $wgExtraNamespaces[NS_SHOW_TALK] = "Show_talk";
+
+      ## User rights
+      $wgGroupPermissions['*']['createaccount'] = false;
+      $wgGroupPermissions['*']['edit'] = false;
+      $wgGroupPermissions['user']['edit'] = true;
+      $wgGroupPermissions['sysop']['createaccount'] = true;
+
+      ## Load extensions
+      wfLoadExtension( 'ParserFunctions' );
+      wfLoadExtension( 'TemplateStyles' );
+      wfLoadExtension( 'Scribunto' );
+      $wgScribuntoDefaultEngine = 'luastandalone';
+
+      ## Load local settings (secrets)
+      if ( file_exists( "$IP/LocalSettings.local.php" ) ) {
+          require_once "$IP/LocalSettings.local.php";
+      }
+    owner: www-data
+    group: www-data
+    mode: '0644'
+
+- name: Create LocalSettings.local.php template
+  copy:
+    dest: "{{ mediawiki_root }}/LocalSettings.local.php.template"
+    content: |
+      <?php
+      # PickiPedia secrets - NOT checked into version control
+      # Copy this to LocalSettings.local.php and fill in values
+
+      # Database
+      $wgDBtype = "mysql";
+      $wgDBserver = "localhost";
+      $wgDBname = "{{ db_name }}";
+      $wgDBuser = "{{ db_user }}";
+      $wgDBpassword = "FILL_IN_PASSWORD";
+
+      # Security keys
+      $wgSecretKey = "FILL_IN_SECRET_KEY";
+      $wgUpgradeKey = "FILL_IN_UPGRADE_KEY";
+
+      # Sentry/GlitchTip (optional)
+      # $wgSentryDsn = "https://...";
+    owner: www-data
+    group: www-data
+    mode: '0600'
+
+- name: Create job runner script
+  copy:
+    dest: /usr/local/bin/mediawiki-jobs.sh
+    mode: '0755'
+    content: |
+      #!/bin/bash
+      # Run MediaWiki job queue
+      cd {{ mediawiki_root }}
+      /usr/bin/php maintenance/runJobs.php --maxjobs=50 --maxtime=60 2>&1 | logger -t mediawiki-jobs
+
+- name: Schedule MediaWiki job runner
+  ansible.builtin.cron:
+    name: "mediawiki job queue"
+    minute: "*/5"
+    job: "/usr/local/bin/mediawiki-jobs.sh"
+    user: www-data
+
+- name: Set permissions on MediaWiki directories
+  file:
+    path: "{{ item }}"
+    state: directory
+    owner: www-data
+    group: www-data
+    mode: '0755'
+    recurse: yes
+  loop:
+    - "{{ mediawiki_root }}/images"
+    - "{{ mediawiki_root }}/cache"
+
+- name: Create migration import script
+  copy:
+    dest: /usr/local/bin/import-pickipedia-backup.sh
+    mode: '0750'
+    content: |
+      #!/bin/bash
+      # Import PickiPedia backup from maybelle
+      set -euo pipefail
+
+      BACKUP_HOST="{{ backup_host }}"
+      BACKUP_PATH="{{ backup_path }}"
+      MW_ROOT="{{ mediawiki_root }}"
+
+      echo "=== PickiPedia Migration Import ==="
+      echo ""
+
+      # Find latest database backup
+      echo "Fetching latest database backup from $BACKUP_HOST..."
+      LATEST_DB=$(ssh root@$BACKUP_HOST "ls -t $BACKUP_PATH/pickipedia_*.sql.gz 2>/dev/null | head -1")
+
+      if [ -z "$LATEST_DB" ]; then
+          echo "ERROR: No database backup found on $BACKUP_HOST"
+          exit 1
+      fi
+
+      echo "Found: $LATEST_DB"
+
+      # Download and import database
+      echo "Downloading database backup..."
+      scp root@$BACKUP_HOST:$LATEST_DB /tmp/pickipedia-import.sql.gz
+
+      echo "Importing database (this may take a while)..."
+      gunzip -c /tmp/pickipedia-import.sql.gz | mysql {{ db_name }}
+
+      echo "Database imported successfully."
+
+      # Import images
+      echo ""
+      echo "Syncing images from $BACKUP_HOST..."
+      rsync -avz --progress root@$BACKUP_HOST:$BACKUP_PATH/images/ $MW_ROOT/images/
+
+      echo "Images synced."
+
+      # Fix ownership
+      chown -R www-data:www-data $MW_ROOT/images
+
+      # Run MediaWiki update
+      echo ""
+      echo "Running MediaWiki update script..."
+      cd $MW_ROOT
+      sudo -u www-data php maintenance/update.php --quick
+
+      echo ""
+      echo "=== Import Complete ==="
+      echo ""
+      echo "Next steps:"
+      echo "1. Copy LocalSettings.local.php.template to LocalSettings.local.php"
+      echo "2. Fill in database password and secret keys"
+      echo "3. Test the wiki: curl -I https://{{ domain_name }}/wiki/Main_Page"
+
+      # Cleanup
+      rm -f /tmp/pickipedia-import.sql.gz

--- a/pickipedia-vps/ansible/roles/nginx/handlers/main.yml
+++ b/pickipedia-vps/ansible/roles/nginx/handlers/main.yml
@@ -1,0 +1,5 @@
+---
+- name: Restart Nginx
+  systemd:
+    name: nginx
+    state: restarted

--- a/pickipedia-vps/ansible/roles/nginx/tasks/main.yml
+++ b/pickipedia-vps/ansible/roles/nginx/tasks/main.yml
@@ -1,0 +1,137 @@
+---
+# Nginx as local PHP-FPM handler
+# Caddy handles SSL termination and proxies to nginx
+
+- name: Install Nginx
+  apt:
+    name: nginx
+    state: present
+
+- name: Create Nginx config for MediaWiki
+  copy:
+    dest: /etc/nginx/sites-available/mediawiki
+    content: |
+      # MediaWiki Nginx configuration
+      # SSL handled by Caddy - this listens on localhost only
+
+      server {
+          listen 127.0.0.1:8080;
+          server_name _;
+
+          root {{ mediawiki_root }};
+          index index.php;
+
+          # Logs
+          access_log /var/log/nginx/mediawiki-access.log;
+          error_log /var/log/nginx/mediawiki-error.log;
+
+          # Client body size (for file uploads)
+          client_max_body_size 100M;
+
+          # MediaWiki short URLs
+          location / {
+              try_files $uri $uri/ @rewrite;
+          }
+
+          location @rewrite {
+              rewrite ^/(.*)$ /index.php?title=$1&$args last;
+          }
+
+          # PHP handling
+          location ~ \.php$ {
+              include fastcgi_params;
+              fastcgi_pass unix:/run/php/php{{ php_version }}-fpm-mediawiki.sock;
+              fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
+              fastcgi_param PATH_INFO $fastcgi_path_info;
+
+              # Increase timeouts for long-running scripts
+              fastcgi_read_timeout 300;
+              fastcgi_send_timeout 300;
+          }
+
+          # MediaWiki API
+          location /api.php {
+              include fastcgi_params;
+              fastcgi_pass unix:/run/php/php{{ php_version }}-fpm-mediawiki.sock;
+              fastcgi_param SCRIPT_FILENAME $document_root/api.php;
+          }
+
+          # REST API
+          location /rest.php {
+              include fastcgi_params;
+              fastcgi_pass unix:/run/php/php{{ php_version }}-fpm-mediawiki.sock;
+              fastcgi_param SCRIPT_FILENAME $document_root/rest.php;
+          }
+
+          # Images
+          location /images {
+              # Serve uploaded files directly
+              # Disable PHP execution in images directory
+              location ~ \.php$ {
+                  deny all;
+              }
+          }
+
+          # Serve static assets directly
+          location /skins {
+              expires 30d;
+          }
+
+          location /resources {
+              expires 30d;
+          }
+
+          location /extensions {
+              # Allow serving static files from extensions
+              # But deny PHP execution to prevent exploits
+              location ~ \.php$ {
+                  deny all;
+              }
+          }
+
+          # Security: deny access to sensitive files
+          location ~ ^/(cache|includes|languages|maintenance|tests|vendor)/ {
+              deny all;
+          }
+
+          location ~ /\. {
+              deny all;
+          }
+
+          # Favicon and robots
+          location = /favicon.ico {
+              log_not_found off;
+              access_log off;
+          }
+
+          location = /robots.txt {
+              allow all;
+              log_not_found off;
+              access_log off;
+          }
+      }
+    mode: '0644'
+  notify: Restart Nginx
+
+- name: Enable MediaWiki site
+  file:
+    src: /etc/nginx/sites-available/mediawiki
+    dest: /etc/nginx/sites-enabled/mediawiki
+    state: link
+  notify: Restart Nginx
+
+- name: Remove default site
+  file:
+    path: /etc/nginx/sites-enabled/default
+    state: absent
+  notify: Restart Nginx
+
+- name: Test Nginx configuration
+  command: nginx -t
+  changed_when: false
+
+- name: Start and enable Nginx
+  systemd:
+    name: nginx
+    state: started
+    enabled: yes

--- a/pickipedia-vps/ansible/roles/php-fpm/handlers/main.yml
+++ b/pickipedia-vps/ansible/roles/php-fpm/handlers/main.yml
@@ -1,0 +1,5 @@
+---
+- name: Restart PHP-FPM
+  systemd:
+    name: php{{ php_version }}-fpm
+    state: restarted

--- a/pickipedia-vps/ansible/roles/php-fpm/tasks/main.yml
+++ b/pickipedia-vps/ansible/roles/php-fpm/tasks/main.yml
@@ -1,0 +1,132 @@
+---
+# PHP-FPM installation for MediaWiki
+# MediaWiki 1.43 requires PHP 8.1+, we use 8.2
+
+- name: Add PHP repository (ondrej/php PPA)
+  apt_repository:
+    repo: ppa:ondrej/php
+    state: present
+  when: ansible_distribution == 'Ubuntu'
+
+- name: Install PHP and extensions for MediaWiki
+  apt:
+    name:
+      # Core PHP
+      - php{{ php_version }}-fpm
+      - php{{ php_version }}-cli
+      # Required extensions
+      - php{{ php_version }}-mysql
+      - php{{ php_version }}-xml
+      - php{{ php_version }}-mbstring
+      - php{{ php_version }}-intl
+      - php{{ php_version }}-curl
+      - php{{ php_version }}-gd
+      - php{{ php_version }}-zip
+      # Recommended extensions
+      - php{{ php_version }}-apcu
+      - php{{ php_version }}-opcache
+      - php{{ php_version }}-redis
+      # For various extensions
+      - php{{ php_version }}-bcmath
+      - php{{ php_version }}-soap
+      - php{{ php_version }}-imagick
+      - php{{ php_version }}-lua
+    state: present
+    update_cache: yes
+
+- name: Configure PHP for MediaWiki
+  copy:
+    dest: /etc/php/{{ php_version }}/fpm/conf.d/99-mediawiki.ini
+    content: |
+      ; MediaWiki optimized PHP settings
+
+      ; Memory and execution
+      memory_limit = 256M
+      max_execution_time = 60
+      max_input_time = 60
+      max_input_vars = 5000
+
+      ; Upload settings (for media files)
+      upload_max_filesize = 100M
+      post_max_size = 105M
+      file_uploads = On
+
+      ; Sessions
+      session.save_handler = files
+      session.gc_maxlifetime = 86400
+
+      ; OPcache settings
+      opcache.enable = 1
+      opcache.memory_consumption = 256
+      opcache.max_accelerated_files = 10000
+      opcache.validate_timestamps = 1
+      opcache.revalidate_freq = 60
+
+      ; APCu settings
+      apc.enabled = 1
+      apc.shm_size = 128M
+      apc.enable_cli = 0
+
+      ; Error handling
+      display_errors = Off
+      log_errors = On
+      error_log = /var/log/php{{ php_version }}-fpm-errors.log
+
+      ; Date/time
+      date.timezone = UTC
+    mode: '0644'
+  notify: Restart PHP-FPM
+
+- name: Configure PHP-FPM pool for MediaWiki
+  copy:
+    dest: /etc/php/{{ php_version }}/fpm/pool.d/mediawiki.conf
+    content: |
+      [mediawiki]
+      user = www-data
+      group = www-data
+      listen = /run/php/php{{ php_version }}-fpm-mediawiki.sock
+      listen.owner = www-data
+      listen.group = www-data
+      listen.mode = 0660
+
+      ; Process management
+      pm = dynamic
+      pm.max_children = 50
+      pm.start_servers = 5
+      pm.min_spare_servers = 5
+      pm.max_spare_servers = 35
+      pm.max_requests = 500
+
+      ; Status page (useful for monitoring)
+      pm.status_path = /fpm-status
+      ping.path = /fpm-ping
+
+      ; Slow log
+      slowlog = /var/log/php{{ php_version }}-fpm-slow.log
+      request_slowlog_timeout = 5s
+
+      ; Security
+      php_admin_flag[allow_url_fopen] = on
+      php_admin_value[disable_functions] = exec,passthru,shell_exec,system,proc_open,popen
+      php_admin_value[open_basedir] = /var/www/pickipedia:/tmp:/var/lib/php/sessions
+
+      ; Environment
+      env[HOSTNAME] = $HOSTNAME
+      env[PATH] = /usr/local/bin:/usr/bin:/bin
+      env[TMP] = /tmp
+      env[TMPDIR] = /tmp
+      env[TEMP] = /tmp
+    mode: '0644'
+  notify: Restart PHP-FPM
+
+- name: Remove default www pool
+  file:
+    path: /etc/php/{{ php_version }}/fpm/pool.d/www.conf
+    state: absent
+  notify: Restart PHP-FPM
+
+- name: Start and enable PHP-FPM
+  systemd:
+    name: php{{ php_version }}-fpm
+    state: started
+    enabled: yes


### PR DESCRIPTION
## Summary
- Ansible roles and deploy script for migrating PickiPedia from NearlyFreeSpeech to dedicated Hetzner VPS (89.167.16.89)
- Stack: Ubuntu 24.04, MariaDB 10.11, PHP-FPM 8.2, Nginx + Caddy, MediaWiki 1.43.6
- Includes import script to pull database and images from maybelle backups

## Files Added
- `pickipedia-vps/` - Complete ansible infrastructure
- `maybelle/scripts/deploy-pickipedia.sh` - Deploy script (runs from maybelle like hunter)

## Usage
```bash
echo "$ANSIBLE_VAULT_PASSWORD" | ssh root@maybelle.cryptograss.live \
    /mnt/persist/maybelle-config/maybelle/scripts/deploy-pickipedia.sh --fresh-host
```

## Context
PickiPedia on NFSN hit connection limits during video upload, causing complete PHP failure. Migrating to our own VPS for full control.