### PR TITLE
Update pickipedia VPS: SSH key + new IP (5.78.112.39)

### DIFF
--- a/maybelle/scripts/deploy-pickipedia-remote.py
+++ b/maybelle/scripts/deploy-pickipedia-remote.py
@@ -62,7 +62,7 @@ def main():
 
     # Confirm
     print("\n" + "-" * 60)
-    print("Will deploy PickiPedia VPS (89.167.16.89)")
+    print("Will deploy PickiPedia VPS (5.78.112.39)")
     print("Stack: MariaDB + PHP-FPM + Nginx + Caddy + MediaWiki")
     if fresh_host:
         print("⚠  FRESH HOST MODE: Old SSH host keys will be removed")

--- a/maybelle/scripts/deploy-pickipedia.sh
+++ b/maybelle/scripts/deploy-pickipedia.sh
@@ -19,7 +19,7 @@ JENKINS_REPORTER_FILE="/root/.jenkins_reporter_password"
 TIMESTAMP=$(date +%Y%m%d-%H%M%S)
 LOG_FILE="/mnt/persist/logs/pickipedia-deploy-${TIMESTAMP}.log"
 VAULT_FILE="/tmp/vault_pass_$$"
-PICKIPEDIA_HOST="89.167.16.89"
+PICKIPEDIA_HOST="5.78.112.39"
 
 # Parse arguments
 if [ "$1" = "--fresh-host" ]; then

--- a/pickipedia-vps/ansible/inventory.yml
+++ b/pickipedia-vps/ansible/inventory.yml
@@ -1,7 +1,7 @@
 all:
   hosts:
     pickipedia:  # After picking, a picking encyclopedia
-      ansible_host: 89.167.16.89
+      ansible_host: 5.78.112.39
       ansible_user: root
       ansible_ssh_private_key_file: ~/.ssh/id_ed25519_hunter
   vars:


### PR DESCRIPTION
Updates for pickipedia VPS deployment:
- Add SSH key path to inventory (uses id_ed25519_hunter)
- Update IP to 5.78.112.39 (Falkenstein region, same as hunter/maybelle)

These changes are needed before the deploy will work.