### PR TITLE
Remove non-existent php-lua package

### DIFF
--- a/pickipedia-vps/ansible/roles/php-fpm/tasks/main.yml
+++ b/pickipedia-vps/ansible/roles/php-fpm/tasks/main.yml
@@ -30,7 +30,6 @@
       - php{{ php_version }}-bcmath
       - php{{ php_version }}-soap
       - php{{ php_version }}-imagick
-      - php{{ php_version }}-lua
     state: present
     update_cache: yes
 


### PR DESCRIPTION
php8.2-lua doesn't exist on Ubuntu 24.04. Scribunto uses standalone lua binary instead.