### PR TITLE
Restart nginx to release port 80 before Caddy

### DIFF
--- a/pickipedia-vps/ansible/roles/nginx/tasks/main.yml
+++ b/pickipedia-vps/ansible/roles/nginx/tasks/main.yml
@@ -124,14 +124,13 @@
   file:
     path: /etc/nginx/sites-enabled/default
     state: absent
-  notify: Restart Nginx
 
 - name: Test Nginx configuration
   command: nginx -t
   changed_when: false
 
-- name: Start and enable Nginx
+- name: Restart Nginx to release port 80
   systemd:
     name: nginx
-    state: started
+    state: restarted
     enabled: yes


### PR DESCRIPTION
Nginx's default site listens on port 80. We remove it but handlers don't run until end of play. This explicitly restarts nginx after removing default site so port 80 is free for Caddy.