### PR TITLE
Fix pickipedia-import-bluerailroad: add 'import' subcommand

### DIFF
--- a/maybelle/jobs/pickipedia-import-bluerailroad.groovy
+++ b/maybelle/jobs/pickipedia-import-bluerailroad.groovy
@@ -34,7 +34,7 @@ pipelineJob('pickipedia-import-bluerailroad') {
 
                         stage('Run import') {
                             steps {
-                                sh 'set +x && /opt/blue-railroad-import/bin/python -m blue_railroad_import.cli --chain-data "$CHAIN_DATA" --wiki-url "$WIKI_URL" --username "$BLUERAILROAD_BOT_USERNAME" --password "$BLUERAILROAD_BOT_PASSWORD" -v'
+                                sh 'set +x && /opt/blue-railroad-import/bin/python -m blue_railroad_import.cli import --chain-data "$CHAIN_DATA" --wiki-url "$WIKI_URL" --username "$BLUERAILROAD_BOT_USERNAME" --password "$BLUERAILROAD_BOT_PASSWORD" -v'
                             }
                         }
                     }


### PR DESCRIPTION
The CLI was updated to use subcommands (`import`, `update-submission`, `mark-minted`) but the Jenkins job wasn't updated to include the `import` subcommand, causing the chain data path to be interpreted as the command argument.

**Error before fix:**
```
cli.py: error: argument command: invalid choice: '/var/jenkins_home/shared/chain_data/chainData.json' (choose from import, update-submission, mark-minted)
```

**Fix:** Add `import` subcommand to the CLI invocation.