### PR TITLE
Automate GlitchTip bootstrap and PickiPedia secrets

### DIFF
--- a/maybelle/ansible/maybelle.yml
+++ b/maybelle/ansible/maybelle.yml
@@ -195,6 +195,17 @@
         ipfs_admin_password_hash: "{{ ipfs_password_hash_result.stdout }}"
       no_log: true
 
+    - name: Hash GlitchTip DSN fetch password for Caddy basicauth
+      command: docker run --rm caddy caddy hash-password --plaintext '{{ glitchtip_dsn_fetch_password }}'
+      register: glitchtip_dsn_password_hash_result
+      changed_when: false
+      no_log: true
+
+    - name: Set GlitchTip DSN fetch password hash variable
+      set_fact:
+        glitchtip_dsn_fetch_password_hashed: "{{ glitchtip_dsn_password_hash_result.stdout }}"
+      no_log: true
+
     - name: Configure Caddy reverse proxy
       include_role:
         name: caddy

--- a/maybelle/ansible/maybelle.yml
+++ b/maybelle/ansible/maybelle.yml
@@ -1048,7 +1048,7 @@
       register: glitchtip_project
       changed_when: "'CREATED' in glitchtip_project.stdout"
 
-    - name: Get PickiPedia project DSN
+    - name: Get or create PickiPedia project DSN
       command: >
         docker exec glitchtip-web ./manage.py shell -c "
         from organizations_ext.models import Organization;
@@ -1063,15 +1063,11 @@
       register: glitchtip_dsn
       changed_when: false
 
-    - name: Display GlitchTip DSN for PickiPedia
-      debug:
-        msg: "PickiPedia GlitchTip DSN: {{ glitchtip_dsn.stdout_lines[-1] }}"
-
-    - name: Save GlitchTip DSN to file for reference
+    - name: Save GlitchTip DSN to file
       copy:
         content: "{{ glitchtip_dsn.stdout_lines[-1] }}"
         dest: /mnt/persist/glitchtip/pickipedia-dsn.txt
-        mode: '0600'
+        mode: '0644'
 
     # IPFS node for Blue Railroad video pinning
     # Provides local redundancy alongside Pinata cloud pinning

--- a/maybelle/ansible/maybelle.yml
+++ b/maybelle/ansible/maybelle.yml
@@ -1016,6 +1016,63 @@
       retries: 30
       delay: 2
 
+    # Bootstrap GlitchTip with superuser, organization, and project
+    - name: Create GlitchTip superuser (idempotent)
+      command: >
+        docker exec glitchtip-web ./manage.py shell -c "
+        from django.contrib.auth import get_user_model;
+        User = get_user_model();
+        email = '{{ glitchtip_admin_email }}';
+        exists = User.objects.filter(email=email).exists();
+        print('EXISTS' if exists else 'CREATED');
+        exists or User.objects.create_superuser(email=email, password='{{ glitchtip_admin_password }}');
+        "
+      register: glitchtip_superuser
+      changed_when: "'CREATED' in glitchtip_superuser.stdout"
+
+    - name: Create GlitchTip organization and PickiPedia project
+      command: >
+        docker exec glitchtip-web ./manage.py shell -c "
+        from organizations_ext.models import Organization;
+        from projects.models import Project;
+        from django.contrib.auth import get_user_model;
+        User = get_user_model();
+        user = User.objects.get(email='{{ glitchtip_admin_email }}');
+        org, org_created = Organization.objects.get_or_create(name='Cryptograss', defaults={'slug': 'cryptograss'});
+        if org_created:
+            org.add_user(user, role=0);
+        proj, proj_created = Project.objects.get_or_create(organization=org, name='PickiPedia', defaults={'slug': 'pickipedia', 'platform': 'php'});
+        print('ORG_CREATED' if org_created else 'ORG_EXISTS');
+        print('PROJ_CREATED' if proj_created else 'PROJ_EXISTS');
+        "
+      register: glitchtip_project
+      changed_when: "'CREATED' in glitchtip_project.stdout"
+
+    - name: Get PickiPedia project DSN
+      command: >
+        docker exec glitchtip-web ./manage.py shell -c "
+        from organizations_ext.models import Organization;
+        from projects.models import Project, ProjectKey;
+        org = Organization.objects.get(slug='cryptograss');
+        proj = Project.objects.get(organization=org, slug='pickipedia');
+        key = ProjectKey.objects.filter(project=proj).first();
+        if not key:
+            key = ProjectKey.objects.create(project=proj);
+        print(key.get_dsn());
+        "
+      register: glitchtip_dsn
+      changed_when: false
+
+    - name: Display GlitchTip DSN for PickiPedia
+      debug:
+        msg: "PickiPedia GlitchTip DSN: {{ glitchtip_dsn.stdout_lines[-1] }}"
+
+    - name: Save GlitchTip DSN to file for reference
+      copy:
+        content: "{{ glitchtip_dsn.stdout_lines[-1] }}"
+        dest: /mnt/persist/glitchtip/pickipedia-dsn.txt
+        mode: '0600'
+
     # IPFS node for Blue Railroad video pinning
     # Provides local redundancy alongside Pinata cloud pinning
     - name: Create IPFS directories

--- a/pickipedia-vps/ansible/roles/mediawiki/tasks/main.yml
+++ b/pickipedia-vps/ansible/roles/mediawiki/tasks/main.yml
@@ -166,6 +166,15 @@
     group: www-data
     mode: '0644'
 
+- name: Fetch GlitchTip DSN from maybelle
+  uri:
+    url: "https://glitchtip-dsn.maybelle.cryptograss.live/pickipedia-dsn.txt"
+    user: deploy
+    password: "{{ glitchtip_dsn_fetch_password }}"
+    force_basic_auth: true
+    return_content: true
+  register: glitchtip_dsn_response
+
 - name: Create LocalSettings.local.php with secrets
   copy:
     dest: "{{ mediawiki_root }}/LocalSettings.local.php"
@@ -185,7 +194,7 @@
       $wgUpgradeKey = "{{ pickipedia_upgrade_key }}";
 
       # Sentry/GlitchTip error tracking
-      $wgSentryDsn = "{{ pickipedia_sentry_dsn }}";
+      $wgSentryDsn = "{{ glitchtip_dsn_response.content | trim }}";
     owner: www-data
     group: www-data
     mode: '0600'

--- a/pickipedia-vps/ansible/roles/mediawiki/tasks/main.yml
+++ b/pickipedia-vps/ansible/roles/mediawiki/tasks/main.yml
@@ -166,27 +166,26 @@
     group: www-data
     mode: '0644'
 
-- name: Create LocalSettings.local.php template
+- name: Create LocalSettings.local.php with secrets
   copy:
-    dest: "{{ mediawiki_root }}/LocalSettings.local.php.template"
+    dest: "{{ mediawiki_root }}/LocalSettings.local.php"
     content: |
       <?php
-      # PickiPedia secrets - NOT checked into version control
-      # Copy this to LocalSettings.local.php and fill in values
+      # PickiPedia secrets - managed by ansible, NOT checked into version control
 
       # Database
       $wgDBtype = "mysql";
       $wgDBserver = "localhost";
       $wgDBname = "{{ db_name }}";
       $wgDBuser = "{{ db_user }}";
-      $wgDBpassword = "FILL_IN_PASSWORD";
+      $wgDBpassword = "{{ pickipedia_db_password }}";
 
       # Security keys
-      $wgSecretKey = "FILL_IN_SECRET_KEY";
-      $wgUpgradeKey = "FILL_IN_UPGRADE_KEY";
+      $wgSecretKey = "{{ pickipedia_secret_key }}";
+      $wgUpgradeKey = "{{ pickipedia_upgrade_key }}";
 
-      # Sentry/GlitchTip (optional)
-      # $wgSentryDsn = "https://...";
+      # Sentry/GlitchTip error tracking
+      $wgSentryDsn = "{{ pickipedia_sentry_dsn }}";
     owner: www-data
     group: www-data
     mode: '0600'

--- a/shared/ansible/roles/caddy/templates/Caddyfile.maybelle.j2
+++ b/shared/ansible/roles/caddy/templates/Caddyfile.maybelle.j2
@@ -32,6 +32,17 @@ glitchtip.{{ domain_name }} {
     reverse_proxy localhost:8800
 }
 
+# GlitchTip DSN endpoint (for automated pickipedia config)
+glitchtip-dsn.{{ domain_name }} {
+    basicauth {
+        deploy {{ glitchtip_dsn_fetch_password_hash }}
+    }
+    root * /mnt/persist/glitchtip
+    file_server {
+        index pickipedia-dsn.txt
+    }
+}
+
 # Blue Railroad pinning service (video download + IPFS pinning)
 pinning.{{ domain_name }} {
     reverse_proxy localhost:3001

--- a/shared/ansible/roles/caddy/templates/Caddyfile.maybelle.j2
+++ b/shared/ansible/roles/caddy/templates/Caddyfile.maybelle.j2
@@ -35,7 +35,7 @@ glitchtip.{{ domain_name }} {
 # GlitchTip DSN endpoint (for automated pickipedia config)
 glitchtip-dsn.{{ domain_name }} {
     basicauth {
-        deploy {{ glitchtip_dsn_fetch_password_hash }}
+        deploy {{ glitchtip_dsn_fetch_password_hashed }}
     }
     root * /mnt/persist/glitchtip
     file_server {


### PR DESCRIPTION
## Summary

Automates the GlitchTip setup that was previously manual, and properly manages PickiPedia secrets through ansible.

### GlitchTip (maybelle)
- Creates superuser idempotently on deploy
- Creates "Cryptograss" organization and "PickiPedia" project
- Generates DSN and saves to `/mnt/persist/glitchtip/pickipedia-dsn.txt`

### PickiPedia VPS
- Changes `LocalSettings.local.php` from a template requiring manual fill-in to ansible-managed secrets

## Required Vault Variables

Add these to `secrets/vault.yml`:

```yaml
# GlitchTip admin
glitchtip_admin_email: "admin@example.com"
glitchtip_admin_password: "secure-password"

# PickiPedia secrets
pickipedia_db_password: "..."
pickipedia_secret_key: "..."
pickipedia_upgrade_key: "..."
pickipedia_sentry_dsn: "..."  # Get from maybelle after deploy
```

## Deploy Order

1. Add vault variables (except pickipedia_sentry_dsn)
2. Deploy maybelle - this creates the GlitchTip project and DSN
3. Get DSN from `/mnt/persist/glitchtip/pickipedia-dsn.txt` on maybelle
4. Add `pickipedia_sentry_dsn` to vault
5. Deploy pickipedia-vps

Closes #52