### PR TITLE
Add delivery-kid IPFS/BitTorrent distribution server

### DIFF
--- a/delivery-kid/ansible/inventory.yml
+++ b/delivery-kid/ansible/inventory.yml
@@ -1,0 +1,24 @@
+all:
+  hosts:
+    delivery-kid:
+      ansible_host: 46.62.220.103
+      ansible_user: root
+      ansible_ssh_private_key_file: ~/.ssh/id_ed25519_hunter
+  vars:
+    # Hetzner CX22 VPS
+    # Domain and SSL
+    domain_name: delivery-kid.cryptograss.live
+    ipfs_gateway_domain: ipfs.delivery-kid.cryptograss.live
+
+    # IPFS configuration
+    ipfs_version: "0.27.0"
+    ipfs_storage_max: "900GB"
+
+    # Hetzner Storage Box BX11
+    storage_box_host: "u554727.your-storagebox.de"
+    storage_box_user: "u554727"
+    storage_box_mount: "/mnt/storage-box"
+    storage_box_password: "{{ vault_storage_box_password }}"
+
+    # Torrent seeding
+    torrent_upload_limit: "10M"

--- a/maybelle/scripts/deploy-delivery-kid-remote.py
+++ b/maybelle/scripts/deploy-delivery-kid-remote.py
@@ -1,0 +1,103 @@
+#!/usr/bin/env python3
+"""
+Deploy delivery-kid from your laptop via maybelle
+
+This script:
+1. Gets the vault password from your environment
+2. SSHs to maybelle and runs the deploy script there
+3. The deploy script on maybelle handles ansible
+
+Usage:
+    ./deploy-delivery-kid-remote.py           # Normal deploy
+    ./deploy-delivery-kid-remote.py --fresh-host  # Fresh server (resets SSH keys)
+
+Prerequisites:
+- SSH access to maybelle from your laptop
+- Vault password in ANSIBLE_VAULT_PASSWORD or ANSIBLE_VAULT_PASSWORD_FILE
+"""
+
+import subprocess
+import sys
+import os
+import getpass
+
+
+def get_vault_password():
+    """Get vault password from environment or file"""
+    password = os.environ.get('ANSIBLE_VAULT_PASSWORD')
+    if password:
+        return password
+
+    password_file = os.environ.get('ANSIBLE_VAULT_PASSWORD_FILE')
+    if password_file:
+        try:
+            with open(password_file, 'r') as f:
+                return f.read().strip()
+        except FileNotFoundError:
+            raise Exception(f"Vault password file not found: {password_file}")
+
+    raise Exception("Neither ANSIBLE_VAULT_PASSWORD nor ANSIBLE_VAULT_PASSWORD_FILE is set")
+
+
+def main():
+    # Parse arguments
+    fresh_host = '--fresh-host' in sys.argv
+
+    print("=" * 60)
+    print("DEPLOY DELIVERY-KID VIA MAYBELLE")
+    if fresh_host:
+        print("(FRESH HOST - will reset SSH keys)")
+    print("=" * 60)
+    print()
+
+    # Check for vault password early
+    try:
+        vault_password = get_vault_password()
+        print("✓ Vault password found")
+    except Exception as e:
+        print(f"\n✗ ERROR: {e}")
+        print("\nSet one of:")
+        print("  export ANSIBLE_VAULT_PASSWORD='your-password'")
+        print("  export ANSIBLE_VAULT_PASSWORD_FILE='/path/to/password/file'")
+        sys.exit(1)
+
+    # Confirm
+    print("\n" + "-" * 60)
+    print("Will deploy delivery-kid (IPFS + BitTorrent server)")
+    print("  VPS: 46.62.220.103")
+    print("  Storage Box: u554727.your-storagebox.de")
+    if fresh_host:
+        print("⚠  FRESH HOST MODE: Old SSH host keys will be removed")
+    print("-" * 60)
+
+    confirm = input("\nContinue? (y/n): ").strip().lower()
+    if confirm != 'y':
+        print("Cancelled")
+        sys.exit(0)
+
+    # Get local username to pass to maybelle
+    local_user = getpass.getuser()
+
+    # Run deploy script on maybelle, passing vault password via stdin
+    print("\nConnecting to maybelle...")
+    print()
+
+    maybelle = 'root@maybelle.cryptograss.live'
+    deploy_script = '/mnt/persist/maybelle-config/maybelle/scripts/deploy-delivery-kid.sh'
+
+    # Pass --fresh-host flag to the remote script
+    script_args = f'{deploy_script} {local_user}'
+    if fresh_host:
+        script_args += ' --fresh-host'
+
+    result = subprocess.run(
+        ['ssh', '-t', maybelle, script_args],
+        input=vault_password + '\n',
+        text=True
+    )
+
+    sys.exit(result.returncode)
+
+
+if __name__ == '__main__':
+    main()

--- a/maybelle/scripts/deploy-delivery-kid.sh
+++ b/maybelle/scripts/deploy-delivery-kid.sh
@@ -1,0 +1,150 @@
+#!/bin/bash
+#
+# Deploy delivery-kid from maybelle
+# This script runs ON maybelle and handles the full deploy
+#
+# The vault password is passed via stdin from the caller's laptop.
+#
+# Usage from laptop:
+#   echo "$ANSIBLE_VAULT_PASSWORD" | ssh root@maybelle.cryptograss.live /mnt/persist/maybelle-config/maybelle/scripts/deploy-delivery-kid.sh [username] [--fresh-host]
+#
+
+set -o pipefail
+# Note: NOT using 'set -e' because we want to handle errors explicitly
+
+DEPLOY_USER="${1:-remote}"
+FRESH_HOST=false
+REPO_DIR="/mnt/persist/maybelle-config"
+TIMESTAMP=$(date +%Y%m%d-%H%M%S)
+LOG_FILE="/mnt/persist/logs/delivery-kid-deploy-${TIMESTAMP}.log"
+VAULT_FILE="/tmp/vault_pass_$$"
+DELIVERY_KID_HOST="delivery-kid.cryptograss.live"
+DELIVERY_KID_IP="46.62.220.103"
+
+# Parse arguments
+if [ "$2" = "--fresh-host" ] || [ "$1" = "--fresh-host" ]; then
+    FRESH_HOST=true
+    if [ "$1" = "--fresh-host" ]; then
+        DEPLOY_USER="remote"
+    fi
+fi
+
+echo "============================================================"
+echo "DEPLOY DELIVERY-KID FROM MAYBELLE"
+if [ "$FRESH_HOST" = true ]; then
+    echo "(FRESH HOST - will reset SSH keys)"
+fi
+echo "============================================================"
+echo ""
+echo "Deploy user: $DEPLOY_USER"
+echo "Target: $DELIVERY_KID_HOST ($DELIVERY_KID_IP)"
+echo ""
+
+# Read vault password from stdin
+echo "Reading vault password from stdin..."
+read -r VAULT_PASSWORD
+if [ -z "$VAULT_PASSWORD" ]; then
+    echo "ERROR: No vault password provided on stdin"
+    exit 1
+fi
+
+# Write to temp file
+echo "$VAULT_PASSWORD" > "$VAULT_FILE"
+chmod 600 "$VAULT_FILE"
+echo "✓ Vault password received"
+
+# Ensure log directory exists
+mkdir -p /mnt/persist/logs
+
+# Cleanup function (keep logs, only remove vault file)
+cleanup() {
+    rm -f "$VAULT_FILE"
+}
+trap cleanup EXIT
+
+# Update repository
+echo ""
+echo "Updating maybelle-config repository..."
+cd "$REPO_DIR"
+
+# Ensure we can fetch all branches (fixes shallow single-branch clones)
+git remote set-branches origin '*'
+git fetch origin main production
+
+# Hard reset to production (handles force pushes/rebases)
+git checkout production 2>/dev/null || git checkout -b production origin/production
+git reset --hard origin/production
+
+# Check that production is not behind main
+if ! git merge-base --is-ancestor origin/main origin/production; then
+    echo "ERROR: production branch is behind main"
+    echo "Please update production to include latest main changes"
+    exit 1
+fi
+echo "✓ Repository updated"
+
+# Handle fresh host SSH keys
+if [ "$FRESH_HOST" = true ]; then
+    echo ""
+    echo "============================================================"
+    echo "HANDLING FRESH HOST SSH KEYS"
+    echo "============================================================"
+    echo ""
+
+    echo "Removing old SSH host keys for $DELIVERY_KID_HOST and $DELIVERY_KID_IP..."
+    ssh-keygen -R "$DELIVERY_KID_HOST" 2>/dev/null || true
+    ssh-keygen -R "$DELIVERY_KID_IP" 2>/dev/null || true
+    echo "✓ Old host keys removed"
+
+    echo ""
+    echo "Fetching new SSH host key..."
+    ssh-keyscan -H "$DELIVERY_KID_HOST" >> ~/.ssh/known_hosts 2>/dev/null
+    ssh-keyscan -H "$DELIVERY_KID_IP" >> ~/.ssh/known_hosts 2>/dev/null
+    echo "✓ New host key added to known_hosts"
+fi
+
+# Run ansible
+echo ""
+echo "============================================================"
+echo "RUNNING ANSIBLE PLAYBOOK"
+echo "============================================================"
+echo ""
+
+START_TIME=$(date +%s)
+
+cd "$REPO_DIR/delivery-kid/ansible"
+
+# Run ansible playbook
+ANSIBLE_CMD="ansible-playbook --vault-password-file=\"$VAULT_FILE\" -i inventory.yml playbook.yml"
+
+if bash -c "$ANSIBLE_CMD" 2>&1 | tee "$LOG_FILE"; then
+    DEPLOY_STATUS="success"
+    EXIT_CODE=0
+    echo ""
+    echo "✓ Deployment complete"
+else
+    DEPLOY_STATUS="failure"
+    EXIT_CODE=1
+    echo ""
+    echo "✗ Deployment failed"
+fi
+
+END_TIME=$(date +%s)
+DURATION=$((END_TIME - START_TIME))
+
+echo ""
+echo "============================================================"
+echo "Deployment took ${DURATION} seconds"
+echo "Full deployment log saved to: $LOG_FILE"
+echo ""
+if [ $EXIT_CODE -eq 0 ]; then
+    echo "✓ SUCCESS"
+    echo ""
+    echo "Services should be available at:"
+    echo "  - https://delivery-kid.cryptograss.live/api/health"
+    echo "  - https://ipfs.delivery-kid.cryptograss.live/ipfs/<CID>"
+else
+    echo "✗ FAILED"
+fi
+
+exit $EXIT_CODE


### PR DESCRIPTION
## Summary

Adds `delivery-kid/` - an IPFS and BitTorrent distribution server for Cryptograss music releases.

### Architecture

Uses a split-storage approach to keep costs low (~€6.50/month):

- **Hetzner CX22 VPS** (€3.29/mo) - 2 vCPU, 4GB RAM, 40GB NVMe
  - IPFS metadata, DHT routing, system
  - Pinning service API
  - aria2 BitTorrent seeder
  
- **Hetzner Storage Box BX11** (€3.20/mo) - 1TB HDD via SMB
  - IPFS blocks (the actual pinned content)
  - Mounted via CIFS, symlinked to `.ipfs/blocks`

```
┌─────────────────────────────────────────────┐
│            Hetzner CX22 VPS                 │
│  ┌─────────────┐  ┌──────────┐  ┌───────┐  │
│  │   Pinning   │  │   IPFS   │  │ aria2 │  │
│  │   Service   │  │  Daemon  │  │       │  │
│  └──────┬──────┘  └────┬─────┘  └───────┘  │
│         └───────┬──────┘                    │
│    40GB NVMe: metadata, DHT, OS             │
│                 │                           │
│                 │ symlink .ipfs/blocks      │
└─────────────────┼───────────────────────────┘
                  │ SMB mount
                  ▼
┌─────────────────────────────────────────────┐
│      Hetzner Storage Box (1TB HDD)          │
│         IPFS blocks (flatfs)                │
└─────────────────────────────────────────────┘
```

### Why this split?

IPFS stores two kinds of data:
- **Metadata** (DHT, peer info, indexes) - small, latency-sensitive → local NVMe
- **Blocks** (actual content) - large, write-once, read-sequential → cheap network storage

### New files

```
delivery-kid/
├── README.md
├── ansible/
│   ├── inventory.yml          # Actual config (46.62.220.103)
│   ├── inventory.yml.example
│   ├── playbook.yml
│   └── roles/
│       ├── aria2/
│       ├── ipfs/
│       ├── pinning-service/
│       └── storage-box/       # Mounts Hetzner Storage Box via CIFS
└── pinning-service/
    ├── package.json
    └── server.js

maybelle/scripts/
├── deploy-delivery-kid-remote.py  # Run from laptop
└── deploy-delivery-kid.sh         # Runs on maybelle
```

### Deployment

```bash
./maybelle/scripts/deploy-delivery-kid-remote.py --fresh-host
```

### Related

- **delivery-driver** ([repo](https://github.com/magent-cryptograss/delivery-driver)) - CLI tool for creating releases, runs on your laptop

## Test plan

- [ ] Run `deploy-delivery-kid-remote.py --fresh-host` from laptop
- [ ] Verify Storage Box mounts at `/mnt/storage-box`
- [ ] Verify IPFS blocks symlink points to Storage Box
- [ ] Test `curl https://delivery-kid.cryptograss.live/api/health`
- [ ] Test pinning a CID via the API
- [ ] Verify content accessible via `https://ipfs.delivery-kid.cryptograss.live/ipfs/<CID>`