### PR TITLE
Fix CIFS mount permissions for IPFS container

### DIFF
--- a/delivery-kid/ansible/playbook.yml
+++ b/delivery-kid/ansible/playbook.yml
@@ -62,7 +62,8 @@
         path: /mnt/storage-box
         src: "//{{ storage_box_host }}/backup"
         fstype: cifs
-        opts: "credentials=/root/.storage-box-credentials,uid=0,gid=0,file_mode=0755,dir_mode=0755"
+        # uid/gid 1000 matches the 'ipfs' user inside the kubo container
+        opts: "credentials=/root/.storage-box-credentials,uid=1000,gid=1000,file_mode=0755,dir_mode=0755"
         state: mounted
 
     # Create directories for IPFS and pinning service


### PR DESCRIPTION
The kubo container runs as user `ipfs` (uid 1000), not root.

Currently the Storage Box mount uses `uid=0,gid=0`, causing:
```
Error: open /data/ipfs/blocks/SHARDING: permission denied
```

This fix mounts with `uid=1000,gid=1000` so IPFS can write to the blocks directory.