### PR TITLE
Fix Caddy path routing with named matcher

### DIFF
--- a/delivery-kid/ansible/playbook.yml
+++ b/delivery-kid/ansible/playbook.yml
@@ -180,17 +180,13 @@
         dest: /etc/caddy/Caddyfile
         content: |
           {{ domain_name }} {
-              reverse_proxy /health localhost:3001
-              reverse_proxy /time localhost:3001
-              reverse_proxy /pin* localhost:3001
-              reverse_proxy /transcode* localhost:3001
-              reverse_proxy /job* localhost:3001
-              reverse_proxy /local-pins localhost:3001
-              reverse_proxy /webhook/* localhost:3001
-
-              handle {
-                  respond "delivery-kid pinning service" 200
+              @pinning {
+                  path /health /time /local-pins
+                  path /pin* /transcode* /job* /webhook/*
               }
+              reverse_proxy @pinning localhost:3001
+
+              respond "delivery-kid pinning service" 200
           }
 
           {{ ipfs_gateway_domain }} {


### PR DESCRIPTION
Multiple `reverse_proxy /path` directives weren't matching correctly. 

This uses a named matcher `@pinning` to group all pinning service paths, then a single `reverse_proxy @pinning` directive. This is more explicit and should work reliably.