### PR TITLE
Caddy: use route directive for explicit ordering

### DIFF
--- a/delivery-kid/ansible/playbook.yml
+++ b/delivery-kid/ansible/playbook.yml
@@ -169,11 +169,23 @@
       retries: 30
       delay: 2
 
-    # Caddy reverse proxy
+    # Caddy reverse proxy - install from official repo (not Ubuntu's)
+    - name: Add Caddy GPG key
+      apt_key:
+        url: https://dl.cloudsmith.io/public/caddy/stable/gpg.key
+        state: present
+
+    - name: Add Caddy repository
+      apt_repository:
+        repo: "deb https://dl.cloudsmith.io/public/caddy/stable/deb/debian any-version main"
+        state: present
+        filename: caddy-stable
+
     - name: Install Caddy
       apt:
         name: caddy
         state: present
+        update_cache: yes
 
     - name: Configure Caddy
       copy:
@@ -196,10 +208,16 @@
               reverse_proxy localhost:8080
           }
         mode: '0644'
-      notify: Reload Caddy
+      notify: Restart Caddy
 
-  handlers:
-    - name: Reload Caddy
+    - name: Start and enable Caddy
       systemd:
         name: caddy
-        state: reloaded
+        state: started
+        enabled: yes
+
+  handlers:
+    - name: Restart Caddy
+      systemd:
+        name: caddy
+        state: restarted

--- a/delivery-kid/ansible/playbook.yml
+++ b/delivery-kid/ansible/playbook.yml
@@ -180,13 +180,16 @@
         dest: /etc/caddy/Caddyfile
         content: |
           {{ domain_name }} {
-              @pinning {
-                  path /health /time /local-pins
-                  path /pin* /transcode* /job* /webhook/*
+              route {
+                  reverse_proxy /health localhost:3001
+                  reverse_proxy /time localhost:3001
+                  reverse_proxy /local-pins localhost:3001
+                  reverse_proxy /pin* localhost:3001
+                  reverse_proxy /transcode* localhost:3001
+                  reverse_proxy /job* localhost:3001
+                  reverse_proxy /webhook/* localhost:3001
+                  respond "delivery-kid pinning service" 200
               }
-              reverse_proxy @pinning localhost:3001
-
-              respond "delivery-kid pinning service" 200
           }
 
           {{ ipfs_gateway_domain }} {


### PR DESCRIPTION
Multiple fixes for Caddy routing:

1. Use `route` directive for explicit path ordering
2. Install Caddy from official cloudsmith.io repo (not Ubuntu's package)
3. Change handler from reload to restart
4. Add explicit start/enable task

Matching the pickipedia pattern which works reliably.