### PR TITLE
Remove recreate: always from delivery-kid docker-compose

### DIFF
--- a/delivery-kid/ansible/playbook.yml
+++ b/delivery-kid/ansible/playbook.yml
@@ -157,13 +157,7 @@
       community.docker.docker_compose_v2:
         project_src: /opt/pinning-service
         build: always
-        recreate: always
         state: present
-
-    # IPFS with Storage Box mount takes time to initialize
-    - name: Wait for containers to stabilize
-      pause:
-        seconds: 15
 
     - name: Wait for IPFS to initialize
       uri:


### PR DESCRIPTION
The `recreate: always` was causing IPFS to restart on every deploy, and it consistently fails to come back up in time with the Storage Box mount.

Removed it - containers will only be recreated when the compose config actually changes. This matches standard docker-compose behavior.