### PR TITLE
Fix IPFS config ordering - configure before health check

### DIFF
--- a/delivery-kid/ansible/playbook.yml
+++ b/delivery-kid/ansible/playbook.yml
@@ -159,17 +159,16 @@
         build: always
         state: present
 
-    - name: Wait for IPFS to initialize
-      uri:
-        url: http://127.0.0.1:5001/api/v0/id
-        method: POST
-        status_code: [200]
-      register: ipfs_health
-      until: ipfs_health.status == 200
-      retries: 45
-      delay: 4
+    # Wait for IPFS container to be running (not API - that won't work until configured)
+    - name: Wait for IPFS container to start
+      command: docker inspect -f '{{.State.Running}}' ipfs
+      register: ipfs_container_state
+      until: ipfs_container_state.stdout == 'true'
+      retries: 30
+      delay: 2
 
-    # Configure IPFS API to listen on all interfaces so pinning service can reach it
+    # Configure IPFS API to listen on all interfaces BEFORE health check
+    # The API won't be reachable from host until this is done
     - name: Check IPFS API listen address
       command: docker exec ipfs ipfs config Addresses.API
       register: ipfs_api_addr
@@ -194,17 +193,18 @@
 
         - name: Start IPFS after config change
           command: docker start ipfs
-
-        - name: Wait for IPFS to be ready after config
-          uri:
-            url: http://127.0.0.1:5001/api/v0/id
-            method: POST
-            status_code: [200]
-          register: ipfs_reconfig_health
-          until: ipfs_reconfig_health.status == 200
-          retries: 30
-          delay: 2
       when: "'/ip4/0.0.0.0/' not in ipfs_api_addr.stdout"
+
+    # NOW health check - API should be reachable
+    - name: Wait for IPFS API to be ready
+      uri:
+        url: http://127.0.0.1:5001/api/v0/id
+        method: POST
+        status_code: [200]
+      register: ipfs_health
+      until: ipfs_health.status == 200
+      retries: 30
+      delay: 2
 
     - name: Wait for pinning service to be ready
       uri:


### PR DESCRIPTION
The IPFS API health check was failing because IPFS listens on 127.0.0.1:5001 inside the container by default. Docker port forwarding from host to container doesn't work with container loopback binding.

Restructured to:
1. Wait for container to be running (not API)
2. Check and configure IPFS to listen on 0.0.0.0:5001
3. THEN do the API health check

This breaks the chicken-and-egg problem where we couldn't configure IPFS because the health check failed first.