### PR TITLE
Add /version endpoint and fix Dockerfile to include all JS files

### DIFF
--- a/delivery-kid/ansible/playbook.yml
+++ b/delivery-kid/ansible/playbook.yml
@@ -109,6 +109,7 @@
                 context: .
               container_name: pinning-service
               environment:
+                - NODE_NAME=delivery-kid
                 - PORT=3001
                 - PINATA_JWT={{ pinata_jwt }}
                 - AUTHORIZED_WALLETS={{ pinning_authorized_wallets }}

--- a/delivery-kid/ansible/playbook.yml
+++ b/delivery-kid/ansible/playbook.yml
@@ -98,6 +98,14 @@
 
     # Docker Compose for IPFS + Pinning Service
     # Same as maybelle, just different URLs
+    - name: Get git commit hash
+      local_action:
+        module: command
+        cmd: git rev-parse --short HEAD
+        chdir: "{{ playbook_dir }}/../../"
+      register: git_commit
+      changed_when: false
+
     - name: Create docker-compose file
       copy:
         dest: /opt/pinning-service/docker-compose.yml
@@ -107,6 +115,9 @@
             pinning:
               build:
                 context: .
+                args:
+                  GIT_COMMIT: "{{ git_commit.stdout }}"
+                  BUILD_TIME: "{{ ansible_date_time.iso8601 }}"
               container_name: pinning-service
               environment:
                 - NODE_NAME=delivery-kid

--- a/delivery-kid/ansible/playbook.yml
+++ b/delivery-kid/ansible/playbook.yml
@@ -268,12 +268,15 @@
           {{ domain_name }} {
               route {
                   reverse_proxy /health localhost:3001
+                  reverse_proxy /version localhost:3001
                   reverse_proxy /time localhost:3001
                   reverse_proxy /local-pins localhost:3001
                   reverse_proxy /pin* localhost:3001
                   reverse_proxy /transcode* localhost:3001
                   reverse_proxy /job* localhost:3001
                   reverse_proxy /webhook/* localhost:3001
+                  reverse_proxy /sync/* localhost:3001
+                  reverse_proxy /releases localhost:3001
                   respond "delivery-kid pinning service" 200
               }
           }

--- a/maybelle/ansible/maybelle.yml
+++ b/maybelle/ansible/maybelle.yml
@@ -1115,6 +1115,14 @@
         dest: /mnt/persist/pinning-service/
         mode: '0644'
 
+    - name: Get git commit hash for pinning service
+      local_action:
+        module: command
+        cmd: git rev-parse --short HEAD
+        chdir: "{{ playbook_dir }}/../"
+      register: pinning_git_commit
+      changed_when: false
+
     - name: Create pinning service docker-compose file
       copy:
         dest: /mnt/persist/pinning-service/docker-compose.yml
@@ -1124,8 +1132,12 @@
             pinning:
               build:
                 context: .
+                args:
+                  GIT_COMMIT: "{{ pinning_git_commit.stdout }}"
+                  BUILD_TIME: "{{ ansible_date_time.iso8601 }}"
               container_name: pinning-service
               environment:
+                - NODE_NAME=maybelle
                 - PORT=3001
                 - PINATA_JWT={{ pinata_jwt }}
                 - AUTHORIZED_WALLETS={{ pinning_authorized_wallets }}

--- a/maybelle/pinning-service/Dockerfile
+++ b/maybelle/pinning-service/Dockerfile
@@ -14,12 +14,18 @@ RUN curl -L https://github.com/yt-dlp/yt-dlp/releases/latest/download/yt-dlp -o 
 
 WORKDIR /app
 
+# Build args for version tracking
+ARG GIT_COMMIT=unknown
+ARG BUILD_TIME=unknown
+ENV GIT_COMMIT=$GIT_COMMIT
+ENV BUILD_TIME=$BUILD_TIME
+
 # Install dependencies
 COPY package.json ./
 RUN npm install --production
 
-# Copy application
-COPY server.js auth.js wiki-update.js ./
+# Copy application (all JS files)
+COPY *.js ./
 
 # Create staging directory
 RUN mkdir -p /staging

--- a/maybelle/pinning-service/aria2-client.js
+++ b/maybelle/pinning-service/aria2-client.js
@@ -1,0 +1,287 @@
+/**
+ * aria2 RPC Client - BitTorrent seeding via aria2c
+ *
+ * Manages torrents for Release pages from PickiPedia.
+ * aria2c runs as a separate container and communicates via JSON-RPC.
+ */
+
+import fetch from 'node-fetch';
+
+const ARIA2_RPC_URL = process.env.ARIA2_RPC_URL || 'http://aria2:6800/jsonrpc';
+const ARIA2_RPC_SECRET = process.env.ARIA2_RPC_SECRET || '';
+const ARIA2_DOWNLOAD_DIR = process.env.ARIA2_DOWNLOAD_DIR || '/downloads';
+
+// Default trackers for magnet links
+const DEFAULT_TRACKERS = [
+  'udp://tracker.opentrackr.org:1337/announce',
+  'udp://tracker.openbittorrent.com:6969/announce',
+  'udp://open.stealth.si:80/announce',
+  'udp://tracker.torrent.eu.org:451/announce'
+];
+
+/**
+ * Make an aria2 JSON-RPC call
+ * @param {string} method - RPC method name (without aria2. prefix)
+ * @param {Array} params - Parameters for the method
+ * @returns {Promise<any>}
+ */
+async function rpcCall(method, params = []) {
+  // Prepend the secret token if configured
+  const fullParams = ARIA2_RPC_SECRET
+    ? [`token:${ARIA2_RPC_SECRET}`, ...params]
+    : params;
+
+  const response = await fetch(ARIA2_RPC_URL, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({
+      jsonrpc: '2.0',
+      id: `pinning-service-${Date.now()}`,
+      method: `aria2.${method}`,
+      params: fullParams
+    })
+  });
+
+  if (!response.ok) {
+    throw new Error(`aria2 RPC error: ${response.status} ${response.statusText}`);
+  }
+
+  const data = await response.json();
+
+  if (data.error) {
+    throw new Error(`aria2 error: ${data.error.message} (code: ${data.error.code})`);
+  }
+
+  return data.result;
+}
+
+/**
+ * Check if aria2 is available
+ * @returns {Promise<boolean>}
+ */
+export async function isAria2Available() {
+  try {
+    await rpcCall('getVersion');
+    return true;
+  } catch (error) {
+    console.warn(`[aria2] Not available: ${error.message}`);
+    return false;
+  }
+}
+
+/**
+ * Get aria2 version info
+ * @returns {Promise<Object>}
+ */
+export async function getVersion() {
+  return rpcCall('getVersion');
+}
+
+/**
+ * Get global stats (download/upload speeds, active torrents)
+ * @returns {Promise<Object>}
+ */
+export async function getGlobalStats() {
+  return rpcCall('getGlobalStat');
+}
+
+/**
+ * Add a torrent by magnet link (infohash)
+ * @param {string} infohash - 40-character hex infohash
+ * @param {string} name - Human-readable name for the torrent
+ * @param {Array<string>} trackers - Optional tracker URLs
+ * @returns {Promise<string>} GID (download identifier)
+ */
+export async function addTorrentByInfohash(infohash, name, trackers = []) {
+  // Build magnet URI
+  let magnetUri = `magnet:?xt=urn:btih:${infohash}`;
+
+  if (name) {
+    magnetUri += `&dn=${encodeURIComponent(name)}`;
+  }
+
+  // Add trackers
+  const allTrackers = [...(trackers.length > 0 ? trackers : DEFAULT_TRACKERS)];
+  for (const tracker of allTrackers) {
+    magnetUri += `&tr=${encodeURIComponent(tracker)}`;
+  }
+
+  console.log(`[aria2] Adding torrent: ${name || infohash}`);
+
+  // Options for seeding
+  const options = {
+    // Seed indefinitely (ratio = 0 means no ratio limit)
+    'seed-ratio': '0.0',
+    // Keep seeding after completion
+    'seed-time': '0',
+    // Directory for downloads
+    dir: ARIA2_DOWNLOAD_DIR
+  };
+
+  return rpcCall('addUri', [[magnetUri], options]);
+}
+
+/**
+ * Add a torrent from a .torrent file (base64 encoded)
+ * @param {string} torrentBase64 - Base64 encoded .torrent file
+ * @param {string} name - Human-readable name
+ * @returns {Promise<string>} GID
+ */
+export async function addTorrentFile(torrentBase64, name = null) {
+  console.log(`[aria2] Adding torrent file: ${name || 'unknown'}`);
+
+  const options = {
+    'seed-ratio': '0.0',
+    'seed-time': '0',
+    dir: ARIA2_DOWNLOAD_DIR
+  };
+
+  return rpcCall('addTorrent', [torrentBase64, [], options]);
+}
+
+/**
+ * Get list of active downloads/seeds
+ * @returns {Promise<Array>}
+ */
+export async function getActiveTorrents() {
+  const active = await rpcCall('tellActive');
+  return active.filter(t => t.bittorrent); // Only BitTorrent, not HTTP downloads
+}
+
+/**
+ * Get list of waiting downloads
+ * @returns {Promise<Array>}
+ */
+export async function getWaitingTorrents() {
+  const waiting = await rpcCall('tellWaiting', [0, 100]);
+  return waiting.filter(t => t.bittorrent);
+}
+
+/**
+ * Get list of stopped/completed downloads
+ * @returns {Promise<Array>}
+ */
+export async function getStoppedTorrents() {
+  const stopped = await rpcCall('tellStopped', [0, 100]);
+  return stopped.filter(t => t.bittorrent);
+}
+
+/**
+ * Get all torrent infohashes currently being seeded
+ * @returns {Promise<Set<string>>}
+ */
+export async function getActiveInfohashes() {
+  const infohashes = new Set();
+
+  try {
+    const [active, waiting, stopped] = await Promise.all([
+      getActiveTorrents(),
+      getWaitingTorrents(),
+      getStoppedTorrents()
+    ]);
+
+    for (const torrent of [...active, ...waiting, ...stopped]) {
+      if (torrent.infoHash) {
+        infohashes.add(torrent.infoHash.toLowerCase());
+      }
+    }
+  } catch (error) {
+    console.error(`[aria2] Failed to get infohashes: ${error.message}`);
+  }
+
+  return infohashes;
+}
+
+/**
+ * Get detailed info about a download
+ * @param {string} gid - Download identifier
+ * @returns {Promise<Object>}
+ */
+export async function getDownloadStatus(gid) {
+  return rpcCall('tellStatus', [gid]);
+}
+
+/**
+ * Remove a download
+ * @param {string} gid - Download identifier
+ * @returns {Promise<string>}
+ */
+export async function removeDownload(gid) {
+  return rpcCall('remove', [gid]);
+}
+
+/**
+ * Pause a download
+ * @param {string} gid - Download identifier
+ * @returns {Promise<string>}
+ */
+export async function pauseDownload(gid) {
+  return rpcCall('pause', [gid]);
+}
+
+/**
+ * Resume a paused download
+ * @param {string} gid - Download identifier
+ * @returns {Promise<string>}
+ */
+export async function unpauseDownload(gid) {
+  return rpcCall('unpause', [gid]);
+}
+
+/**
+ * Force remove a download (even if it's active)
+ * @param {string} gid - Download identifier
+ * @returns {Promise<string>}
+ */
+export async function forceRemove(gid) {
+  return rpcCall('forceRemove', [gid]);
+}
+
+/**
+ * Get a summary of current torrent status
+ * @returns {Promise<Object>}
+ */
+export async function getTorrentSummary() {
+  try {
+    const [stats, active, waiting, stopped, version] = await Promise.all([
+      getGlobalStats(),
+      getActiveTorrents(),
+      getWaitingTorrents(),
+      getStoppedTorrents(),
+      getVersion()
+    ]);
+
+    return {
+      available: true,
+      version: version.version,
+      stats: {
+        downloadSpeed: parseInt(stats.downloadSpeed) || 0,
+        uploadSpeed: parseInt(stats.uploadSpeed) || 0,
+        numActive: parseInt(stats.numActive) || 0,
+        numWaiting: parseInt(stats.numWaiting) || 0,
+        numStopped: parseInt(stats.numStopped) || 0
+      },
+      torrents: {
+        active: active.map(t => ({
+          gid: t.gid,
+          name: t.bittorrent?.info?.name || 'Unknown',
+          infohash: t.infoHash,
+          status: t.status,
+          completedLength: parseInt(t.completedLength) || 0,
+          totalLength: parseInt(t.totalLength) || 0,
+          uploadSpeed: parseInt(t.uploadSpeed) || 0,
+          downloadSpeed: parseInt(t.downloadSpeed) || 0,
+          numSeeders: parseInt(t.numSeeders) || 0,
+          connections: parseInt(t.connections) || 0
+        })),
+        waiting: waiting.length,
+        stopped: stopped.length
+      }
+    };
+  } catch (error) {
+    return {
+      available: false,
+      error: error.message
+    };
+  }
+}

--- a/maybelle/pinning-service/server.js
+++ b/maybelle/pinning-service/server.js
@@ -10,6 +10,8 @@ import Hash from 'ipfs-only-hash';
 import { CID } from 'multiformats/cid';
 import { requireWalletAuth } from './auth.js';
 import { updateSubmissionCid, isWikiConfigured } from './wiki-update.js';
+import { getAllReleases, syncReleases, getSyncStatus } from './wiki-sync.js';
+import { getTorrentSummary, addTorrentByInfohash, getActiveInfohashes, isAria2Available } from './aria2-client.js';
 
 const app = express();
 
@@ -47,17 +49,18 @@ app.use(cors({
 app.use(express.json());
 
 const PORT = process.env.PORT || 3001;
+const NODE_NAME = process.env.NODE_NAME || 'delivery-kid';
 const PINATA_JWT = process.env.PINATA_JWT;
 // Legacy keys kept for backwards compatibility during transition
 const PINATA_API_KEY = process.env.PINATA_API_KEY;
 const PINATA_SECRET_KEY = process.env.PINATA_SECRET_KEY;
 const IPFS_API_URL = process.env.IPFS_API_URL || 'http://ipfs:5001';
-const IPFS_GATEWAY_URL = process.env.IPFS_GATEWAY_URL || 'https://ipfs.maybelle.cryptograss.live';
+const IPFS_GATEWAY_URL = process.env.IPFS_GATEWAY_URL || 'https://ipfs.delivery-kid.cryptograss.live';
 const STAGING_DIR = process.env.STAGING_DIR || '/staging';
 const AUTHORIZED_WALLETS = process.env.AUTHORIZED_WALLETS || '';
 const COCONUT_API_KEY = process.env.COCONUT_API_KEY;
 const JOBS_DIR = process.env.JOBS_DIR || join(STAGING_DIR, 'jobs');
-const WEBHOOK_BASE_URL = process.env.WEBHOOK_BASE_URL || 'https://pinning.maybelle.cryptograss.live';
+const WEBHOOK_BASE_URL = process.env.WEBHOOK_BASE_URL || 'https://delivery-kid.cryptograss.live';
 const PIN_MANIFEST_PATH = process.env.PIN_MANIFEST_PATH || join(STAGING_DIR, 'pin-manifest.json');
 
 // Pin manifest - tracks when CIDs were pinned locally (IPFS doesn't store this)
@@ -138,7 +141,7 @@ app.get('/local-pins', async (req, res) => {
     }));
 
     res.json({
-      node: 'maybelle',
+      node: NODE_NAME,
       fetchedAt: new Date().toISOString(),
       count: pins.length,
       pins
@@ -1301,6 +1304,148 @@ app.get('/jobs', requireWalletAuth, (req, res) => {
   }
 });
 
+// =============================================================================
+// Wiki Sync Endpoints - Sync releases from PickiPedia
+// =============================================================================
+
+// Get sync status
+app.get('/sync/status', async (req, res) => {
+  try {
+    const status = getSyncStatus();
+    res.json(status);
+  } catch (error) {
+    res.status(500).json({ error: error.message });
+  }
+});
+
+// Trigger a manual sync (requires auth)
+app.post('/sync/run', requireWalletAuth, async (req, res) => {
+  try {
+    console.log('[sync] Manual sync triggered');
+    const result = await syncReleases();
+    res.json(result);
+  } catch (error) {
+    console.error('[sync] Error:', error);
+    res.status(500).json({ error: error.message });
+  }
+});
+
+// List all releases from the wiki (public endpoint)
+app.get('/releases', async (req, res) => {
+  try {
+    const filter = req.query.filter || 'all';
+    const releases = await getAllReleases(filter);
+    res.json({
+      count: releases.length,
+      releases
+    });
+  } catch (error) {
+    res.status(500).json({ error: error.message });
+  }
+});
+
+// =============================================================================
+// Torrent Endpoints - BitTorrent seeding via aria2
+// =============================================================================
+
+// Get torrent status summary
+app.get('/torrents/status', async (req, res) => {
+  try {
+    const summary = await getTorrentSummary();
+    res.json(summary);
+  } catch (error) {
+    res.status(500).json({ error: error.message, available: false });
+  }
+});
+
+// Add a torrent by infohash (requires auth)
+app.post('/torrents/add', requireWalletAuth, async (req, res) => {
+  const { infohash, name, trackers } = req.body;
+
+  if (!infohash) {
+    return res.status(400).json({ error: 'infohash is required' });
+  }
+
+  // Validate infohash format (40 hex chars)
+  if (!/^[a-fA-F0-9]{40}$/.test(infohash)) {
+    return res.status(400).json({ error: 'Invalid infohash format (expected 40 hex characters)' });
+  }
+
+  try {
+    const gid = await addTorrentByInfohash(infohash, name, trackers);
+    res.json({ success: true, gid, infohash, name });
+  } catch (error) {
+    res.status(500).json({ error: error.message });
+  }
+});
+
+// Sync torrents from wiki releases (requires auth)
+app.post('/torrents/sync', requireWalletAuth, async (req, res) => {
+  try {
+    // Check if aria2 is available
+    const aria2Ready = await isAria2Available();
+    if (!aria2Ready) {
+      return res.json({
+        status: 'skipped',
+        message: 'aria2 not available'
+      });
+    }
+
+    // Get releases with torrent infohashes
+    const releases = await getAllReleases('torrent');
+    const activeInfohashes = await getActiveInfohashes();
+
+    const results = {
+      checked: releases.length,
+      alreadySeeding: 0,
+      added: 0,
+      failed: 0,
+      details: []
+    };
+
+    for (const release of releases) {
+      const infohash = release.bittorrent_infohash;
+      if (!infohash) continue;
+
+      if (activeInfohashes.has(infohash.toLowerCase())) {
+        results.alreadySeeding++;
+        continue;
+      }
+
+      try {
+        const gid = await addTorrentByInfohash(
+          infohash,
+          release.title,
+          release.bittorrent_trackers
+        );
+        results.added++;
+        results.details.push({
+          action: 'added',
+          title: release.title,
+          infohash,
+          gid
+        });
+      } catch (error) {
+        results.failed++;
+        results.details.push({
+          action: 'failed',
+          title: release.title,
+          infohash,
+          error: error.message
+        });
+      }
+    }
+
+    res.json(results);
+  } catch (error) {
+    res.status(500).json({ error: error.message });
+  }
+});
+
+// =============================================================================
+// Startup
+// =============================================================================
+
 app.listen(PORT, '0.0.0.0', () => {
   console.log(`Blue Railroad Pinning Service listening on port ${PORT}`);
   console.log(`Pinata configured: ${PINATA_JWT ? 'yes (JWT)' : 'NO - uploads will fail'}`);
@@ -1309,4 +1454,9 @@ app.listen(PORT, '0.0.0.0', () => {
   console.log(`IPFS Gateway URL: ${IPFS_GATEWAY_URL}`);
   const walletCount = AUTHORIZED_WALLETS.split(',').filter(w => w.trim()).length;
   console.log(`Wallet auth: ${walletCount} authorized wallet(s)`);
+
+  // Check aria2 availability on startup
+  isAria2Available().then(available => {
+    console.log(`aria2 BitTorrent: ${available ? 'connected' : 'not available'}`);
+  });
 });

--- a/maybelle/pinning-service/server.js
+++ b/maybelle/pinning-service/server.js
@@ -109,6 +109,21 @@ app.get('/health', (req, res) => {
   res.json({ status: 'ok', timestamp: new Date().toISOString() });
 });
 
+// Version info - helps identify which build is running
+const GIT_COMMIT = process.env.GIT_COMMIT || 'unknown';
+const BUILD_TIME = process.env.BUILD_TIME || 'unknown';
+const START_TIME = new Date().toISOString();
+
+app.get('/version', (req, res) => {
+  res.json({
+    node: NODE_NAME,
+    commit: GIT_COMMIT,
+    buildTime: BUILD_TIME,
+    startTime: START_TIME,
+    uptimeSeconds: Math.floor(process.uptime())
+  });
+});
+
 // Server time endpoint - clients use this for auth timestamps to avoid clock drift issues
 app.get('/time', (req, res) => {
   res.json({ timestamp: Date.now() });

--- a/maybelle/pinning-service/wiki-sync.js
+++ b/maybelle/pinning-service/wiki-sync.js
@@ -1,0 +1,217 @@
+/**
+ * Wiki Sync Module - Synchronizes releases from PickiPedia to local IPFS pins
+ *
+ * Queries the Release namespace via the releaselist API and pins any CIDs
+ * that aren't already pinned locally.
+ */
+
+import fetch from 'node-fetch';
+
+const WIKI_URL = process.env.WIKI_URL || 'https://pickipedia.xyz';
+const IPFS_API_URL = process.env.IPFS_API_URL || 'http://ipfs:5001';
+
+// In-memory sync state
+let lastSyncTime = null;
+let lastSyncResult = null;
+let syncInProgress = false;
+
+/**
+ * Fetch all releases from the wiki API
+ * @param {string} filter - 'all', 'ipfs', 'torrent', 'missing-torrent'
+ * @returns {Promise<Array>}
+ */
+export async function getAllReleases(filter = 'all') {
+  const url = `${WIKI_URL}/api.php?action=releaselist&filter=${filter}&format=json`;
+
+  const response = await fetch(url);
+  if (!response.ok) {
+    throw new Error(`Wiki API error: ${response.status} ${response.statusText}`);
+  }
+
+  const data = await response.json();
+  return data.releases || [];
+}
+
+/**
+ * Get all locally pinned CIDs
+ * @returns {Promise<Set<string>>}
+ */
+async function getLocalPins() {
+  const response = await fetch(`${IPFS_API_URL}/api/v0/pin/ls?type=recursive`, {
+    method: 'POST'
+  });
+
+  if (!response.ok) {
+    throw new Error(`IPFS API error: ${response.status}`);
+  }
+
+  const result = await response.json();
+  return new Set(Object.keys(result.Keys || {}));
+}
+
+/**
+ * Pin a CID to the local IPFS node
+ * @param {string} cid - The CID to pin
+ * @param {string} name - Optional name for logging
+ * @returns {Promise<boolean>}
+ */
+async function pinCid(cid, name = null) {
+  console.log(`[wiki-sync] Pinning CID: ${cid}${name ? ` (${name})` : ''}`);
+
+  try {
+    const response = await fetch(`${IPFS_API_URL}/api/v0/pin/add?arg=${cid}&progress=false`, {
+      method: 'POST'
+    });
+
+    if (!response.ok) {
+      const errorText = await response.text();
+      console.error(`[wiki-sync] Failed to pin ${cid}: ${response.status} - ${errorText}`);
+      return false;
+    }
+
+    const result = await response.json();
+    console.log(`[wiki-sync] Successfully pinned: ${cid}`);
+    return true;
+  } catch (error) {
+    console.error(`[wiki-sync] Error pinning ${cid}: ${error.message}`);
+    return false;
+  }
+}
+
+/**
+ * Sync releases from the wiki - pin any missing CIDs
+ * @returns {Promise<Object>} Sync result with counts
+ */
+export async function syncReleases() {
+  if (syncInProgress) {
+    return {
+      status: 'already-running',
+      message: 'Sync already in progress',
+      lastSync: lastSyncResult
+    };
+  }
+
+  syncInProgress = true;
+  const startTime = new Date();
+
+  console.log('[wiki-sync] Starting release sync...');
+
+  try {
+    // Fetch releases and local pins in parallel
+    const [releases, localPins] = await Promise.all([
+      getAllReleases('ipfs'),
+      getLocalPins()
+    ]);
+
+    console.log(`[wiki-sync] Found ${releases.length} releases, ${localPins.size} local pins`);
+
+    const results = {
+      totalReleases: releases.length,
+      totalLocalPins: localPins.size,
+      alreadyPinned: 0,
+      newlyPinned: 0,
+      failedToPPin: 0,
+      skipped: 0,
+      details: []
+    };
+
+    for (const release of releases) {
+      const cid = release.ipfs_cid;
+
+      if (!cid) {
+        results.skipped++;
+        continue;
+      }
+
+      if (localPins.has(cid)) {
+        results.alreadyPinned++;
+        continue;
+      }
+
+      // Pin the missing CID
+      const success = await pinCid(cid, release.title);
+
+      if (success) {
+        results.newlyPinned++;
+        results.details.push({
+          action: 'pinned',
+          cid,
+          title: release.title,
+          pageTitle: release.page_title
+        });
+      } else {
+        results.failedToPPin++;
+        results.details.push({
+          action: 'failed',
+          cid,
+          title: release.title,
+          pageTitle: release.page_title
+        });
+      }
+    }
+
+    const duration = (new Date() - startTime) / 1000;
+    results.duration = duration;
+    results.status = 'completed';
+    results.syncedAt = startTime.toISOString();
+
+    console.log(`[wiki-sync] Sync completed in ${duration.toFixed(1)}s: ` +
+      `${results.newlyPinned} pinned, ${results.alreadyPinned} already present, ` +
+      `${results.failedToPPin} failed, ${results.skipped} skipped`);
+
+    lastSyncTime = startTime;
+    lastSyncResult = results;
+
+    return results;
+
+  } catch (error) {
+    console.error('[wiki-sync] Sync failed:', error.message);
+
+    const errorResult = {
+      status: 'error',
+      error: error.message,
+      syncedAt: startTime.toISOString()
+    };
+
+    lastSyncResult = errorResult;
+    return errorResult;
+
+  } finally {
+    syncInProgress = false;
+  }
+}
+
+/**
+ * Get the current sync status
+ * @returns {Object}
+ */
+export function getSyncStatus() {
+  return {
+    inProgress: syncInProgress,
+    lastSync: lastSyncTime?.toISOString() || null,
+    lastResult: lastSyncResult
+  };
+}
+
+/**
+ * Get releases that need torrent seeding
+ * (have IPFS but missing BitTorrent infohash or not seeding)
+ * @param {Set<string>} activeTorrents - Set of active torrent infohashes
+ * @returns {Promise<Array>}
+ */
+export async function getReleasesNeedingSeeding(activeTorrents = new Set()) {
+  const releases = await getAllReleases('all');
+
+  return releases.filter(release => {
+    // Has IPFS CID
+    if (!release.ipfs_cid) return false;
+
+    // Has torrent infohash but not seeding
+    if (release.bittorrent_infohash) {
+      return !activeTorrents.has(release.bittorrent_infohash.toLowerCase());
+    }
+
+    // No torrent infohash - might need one created
+    return false;
+  });
+}


### PR DESCRIPTION
## Summary
- Added `/version` endpoint to pinning service server.js showing node name, git commit, build time, start time, and uptime
- Fixed Dockerfile to copy ALL JS files (was missing wiki-sync.js and aria2-client.js)
- Added build args (GIT_COMMIT, BUILD_TIME) to both delivery-kid and maybelle ansible playbooks
- Added NODE_NAME environment variable to maybelle playbook

## Why
The wiki-sync module wasn't being deployed to delivery-kid because the Dockerfile only copied specific JS files. This prevented the sync functionality from working. The /version endpoint helps debug which version is running on each node.

## Test plan
- [ ] Deploy to delivery-kid
- [ ] Verify `/version` returns correct commit hash and build time
- [ ] Verify `/sync/status` and `/releases` endpoints work (no longer return fallback text)
- [ ] Verify wiki sync pins Release CIDs