### PR TITLE
Fix bot edit verification for PickiPedia submission updates

### DIFF
--- a/maybelle/pinning-service/wiki-update.js
+++ b/maybelle/pinning-service/wiki-update.js
@@ -215,10 +215,12 @@ export async function updateSubmissionCid(submissionId, ipfsCid) {
     };
   }
 
-  // Update the ipfs_cid field
+  // Update the ipfs_cid field and add status=proposed for bot verification
   let result;
   try {
     result = updateSubmissionField(currentContent, 'ipfs_cid', ipfsCid);
+    // Add status=proposed to satisfy PickiPedia bot edit requirements
+    result = updateSubmissionField(result.wikitext, 'status', 'proposed');
   } catch (err) {
     return {
       action: 'error',


### PR DESCRIPTION
Adds `|status=proposed` to Blue Railroad Submission template when bot updates with IPFS CID. Required by PickiPedia's bot edit verification system.