### PR TITLE
Fix CORS regex for multi-level hunter subdomains

### DIFF
--- a/delivery-kid/pinning-service/app/config.py
+++ b/delivery-kid/pinning-service/app/config.py
@@ -47,7 +47,7 @@ class Settings(BaseSettings):
         "https://www.cryptograss.live",
         "https://pickipedia.xyz",
     ]
-    cors_origin_regex: str = r"https://\w+\d*\.hunter\.cryptograss\.live"
+    cors_origin_regex: str = r"https://[\w.-]+\.hunter\.cryptograss\.live"
 
     class Config:
         env_file = ".env"


### PR DESCRIPTION
One-line fix: CORS regex didn't match `pickipedia.justin.hunter.cryptograss.live` because `\w+\d*` doesn't cross dots.

Changed to `[\w.-]+` so any depth of subdomain under `hunter.cryptograss.live` is allowed.

Found during end-to-end testing of PR #69 — upload from dev wiki was blocked by CORS.