### PR TITLE
Add staging file endpoint for video preview

### DIFF
--- a/delivery-kid/pinning-service/app/main.py
+++ b/delivery-kid/pinning-service/app/main.py
@@ -9,7 +9,7 @@ from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 
 from .config import get_settings
-from .routes import health, albums, drafts, content, enrich, torrent, coconut
+from .routes import health, albums, drafts, content, enrich, torrent, coconut, staging
 from .services import cleanup
 from .services.seeder import init_seeder, stop_seeder
 
@@ -93,6 +93,7 @@ app.include_router(content.router)
 app.include_router(enrich.router)
 app.include_router(torrent.router)
 app.include_router(coconut.router)
+app.include_router(staging.router)
 
 
 @app.get("/")

--- a/delivery-kid/pinning-service/app/routes/staging.py
+++ b/delivery-kid/pinning-service/app/routes/staging.py
@@ -18,17 +18,22 @@ from typing import Optional
 from fastapi import APIRouter, Depends, HTTPException, Query, Request
 from fastapi.responses import FileResponse
 
-from ..auth import verify_upload_token
+from ..auth import require_auth, verify_upload_token
 from ..config import get_settings, Settings
 
 router = APIRouter(prefix="/staging", tags=["staging"])
 
-# Ensure common media types are registered
-mimetypes.add_type("video/mp4", ".mp4")
-mimetypes.add_type("video/webm", ".webm")
-mimetypes.add_type("video/quicktime", ".mov")
-mimetypes.add_type("audio/flac", ".flac")
-mimetypes.add_type("audio/ogg", ".ogg")
+# Ensure common media types are registered (Python's default registry
+# misses some of these on minimal Linux installs)
+_MEDIA_TYPES = {
+    ".mp4": "video/mp4",
+    ".webm": "video/webm",
+    ".mov": "video/quicktime",
+    ".flac": "audio/flac",
+    ".ogg": "audio/ogg",
+}
+for _ext, _mime in _MEDIA_TYPES.items():
+    mimetypes.add_type(_mime, _ext)
 
 
 async def require_staging_auth(
@@ -43,8 +48,8 @@ async def require_staging_auth(
     Query param auth uses the same HMAC verification as header auth,
     just sourced from ?token=&user=&timestamp= instead of X-Upload-* headers.
     """
-    # Try header auth first (X-Upload-Token, X-API-Key, or X-Signature)
-    from ..auth import require_auth
+    # Try header auth first (X-Upload-Token, X-API-Key, or X-Signature).
+    # If it fails, fall through to query param auth below.
     try:
         return await require_auth(request, settings)
     except HTTPException:

--- a/delivery-kid/pinning-service/app/routes/staging.py
+++ b/delivery-kid/pinning-service/app/routes/staging.py
@@ -1,0 +1,101 @@
+"""Serve staged draft files for preview (e.g., video embed on ReleaseDraft pages).
+
+Files are served from the staging directory at /drafts/{draft_id}/upload/{filename}.
+Requires a valid upload token (any logged-in wiki user). Does NOT check draft
+ownership — the unguessable UUID is sufficient access control for preview.
+
+Supports HTTP range requests for video seeking via FastAPI's FileResponse.
+
+Auth can be provided via headers (standard require_auth flow) OR via query
+parameters (?token=...&user=...&timestamp=...) so that <video src="...">
+tags work without JavaScript fetch gymnastics.
+"""
+
+import mimetypes
+from pathlib import Path
+from typing import Optional
+
+from fastapi import APIRouter, Depends, HTTPException, Query, Request
+from fastapi.responses import FileResponse
+
+from ..auth import verify_upload_token
+from ..config import get_settings, Settings
+
+router = APIRouter(prefix="/staging", tags=["staging"])
+
+# Ensure common media types are registered
+mimetypes.add_type("video/mp4", ".mp4")
+mimetypes.add_type("video/webm", ".webm")
+mimetypes.add_type("video/quicktime", ".mov")
+mimetypes.add_type("audio/flac", ".flac")
+mimetypes.add_type("audio/ogg", ".ogg")
+
+
+async def require_staging_auth(
+    request: Request,
+    token: Optional[str] = Query(None),
+    user: Optional[str] = Query(None),
+    timestamp: Optional[str] = Query(None),
+    settings: Settings = Depends(get_settings),
+) -> str:
+    """Authenticate via headers (standard) or query params (for <video src>).
+
+    Query param auth uses the same HMAC verification as header auth,
+    just sourced from ?token=&user=&timestamp= instead of X-Upload-* headers.
+    """
+    # Try header auth first (X-Upload-Token, X-API-Key, or X-Signature)
+    from ..auth import require_auth
+    try:
+        return await require_auth(request, settings)
+    except HTTPException:
+        pass
+
+    # Fall back to query param auth
+    if token and user and timestamp:
+        try:
+            ts = int(timestamp)
+        except (ValueError, TypeError):
+            raise HTTPException(status_code=401, detail="Invalid timestamp")
+
+        if verify_upload_token(token, user, ts, settings, action="upload"):
+            return f"wiki:{user}"
+
+    raise HTTPException(
+        status_code=401,
+        detail="Authentication required (via headers or query params)"
+    )
+
+
+@router.get("/drafts/{draft_id}/{filename}")
+async def get_staging_file(
+    draft_id: str,
+    filename: str,
+    identity: str = Depends(require_staging_auth),
+    settings: Settings = Depends(get_settings),
+):
+    """Serve a file from a staging draft for preview.
+
+    Used by the ReleaseDraft page to embed video/audio players.
+    """
+    # Sanitize path components to prevent traversal
+    if ".." in draft_id or "/" in draft_id or ".." in filename or "/" in filename:
+        raise HTTPException(status_code=400, detail="Invalid path")
+
+    file_path = Path(settings.staging_dir) / "drafts" / draft_id / "upload" / filename
+
+    if not file_path.is_file():
+        raise HTTPException(status_code=404, detail="File not found")
+
+    # Verify the resolved path is still within staging (belt-and-suspenders)
+    try:
+        file_path.resolve().relative_to(Path(settings.staging_dir).resolve())
+    except ValueError:
+        raise HTTPException(status_code=400, detail="Invalid path")
+
+    content_type = mimetypes.guess_type(filename)[0] or "application/octet-stream"
+
+    return FileResponse(
+        path=file_path,
+        media_type=content_type,
+        filename=filename,
+    )

--- a/delivery-kid/pinning-service/tests/test_staging.py
+++ b/delivery-kid/pinning-service/tests/test_staging.py
@@ -1,0 +1,126 @@
+"""Tests for the staging file serving endpoint."""
+
+from pathlib import Path
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from app.config import Settings, get_settings
+from app.routes.staging import router
+
+
+def make_settings(staging_dir: str) -> Settings:
+    """Create test settings pointing at a tmp staging dir."""
+    return Settings(
+        staging_dir=staging_dir,
+        api_key="test-secret",
+        authorized_wallets="",
+    )
+
+
+def make_client(settings: Settings) -> TestClient:
+    """Create a test client with settings overridden via FastAPI DI."""
+    test_app = FastAPI()
+    test_app.include_router(router)
+    test_app.dependency_overrides[get_settings] = lambda: settings
+    return TestClient(test_app)
+
+
+@pytest.fixture
+def staging_dir(tmp_path):
+    """Create a staging directory with a test draft and file."""
+    draft_id = "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"
+    upload_dir = tmp_path / "drafts" / draft_id / "upload"
+    upload_dir.mkdir(parents=True)
+
+    test_file = upload_dir / "test-video.mp4"
+    test_file.write_bytes(b"\x00" * 1024)
+
+    return tmp_path, draft_id
+
+
+def _auth_headers(api_key: str = "test-secret") -> dict:
+    return {"X-API-Key": api_key}
+
+
+class TestStagingEndpoint:
+
+    def test_serves_existing_file(self, staging_dir):
+        tmp_path, draft_id = staging_dir
+        client = make_client(make_settings(str(tmp_path)))
+        resp = client.get(
+            f"/staging/drafts/{draft_id}/test-video.mp4",
+            headers=_auth_headers(),
+        )
+        assert resp.status_code == 200
+        assert resp.headers["content-type"] == "video/mp4"
+        assert len(resp.content) == 1024
+
+    def test_404_for_missing_file(self, staging_dir):
+        tmp_path, draft_id = staging_dir
+        client = make_client(make_settings(str(tmp_path)))
+        resp = client.get(
+            f"/staging/drafts/{draft_id}/nonexistent.mp4",
+            headers=_auth_headers(),
+        )
+        assert resp.status_code == 404
+
+    def test_404_for_missing_draft(self, staging_dir):
+        tmp_path, _ = staging_dir
+        client = make_client(make_settings(str(tmp_path)))
+        resp = client.get(
+            "/staging/drafts/00000000-0000-0000-0000-000000000000/file.mp4",
+            headers=_auth_headers(),
+        )
+        assert resp.status_code == 404
+
+    def test_requires_auth(self, staging_dir):
+        tmp_path, draft_id = staging_dir
+        client = make_client(make_settings(str(tmp_path)))
+        resp = client.get(
+            f"/staging/drafts/{draft_id}/test-video.mp4",
+        )
+        assert resp.status_code == 401
+
+    def test_rejects_bad_api_key(self, staging_dir):
+        tmp_path, draft_id = staging_dir
+        client = make_client(make_settings(str(tmp_path)))
+        resp = client.get(
+            f"/staging/drafts/{draft_id}/test-video.mp4",
+            headers=_auth_headers("wrong-key"),
+        )
+        assert resp.status_code == 401
+
+    def test_query_param_auth(self, staging_dir):
+        """Test that <video src="...?token=&user=&timestamp="> auth works."""
+        import hmac, hashlib, time
+
+        tmp_path, draft_id = staging_dir
+        settings = make_settings(str(tmp_path))
+        client = make_client(settings)
+
+        username = "TestUser"
+        ts = int(time.time() * 1000)
+        token = hmac.new(
+            settings.api_key.encode(),
+            f"upload:{username}:{ts}".encode(),
+            hashlib.sha256,
+        ).hexdigest()
+
+        resp = client.get(
+            f"/staging/drafts/{draft_id}/test-video.mp4"
+            f"?token={token}&user={username}&timestamp={ts}",
+        )
+        assert resp.status_code == 200
+        assert len(resp.content) == 1024
+
+    def test_query_param_auth_rejects_bad_token(self, staging_dir):
+        tmp_path, draft_id = staging_dir
+        client = make_client(make_settings(str(tmp_path)))
+
+        resp = client.get(
+            f"/staging/drafts/{draft_id}/test-video.mp4"
+            f"?token=badtoken&user=TestUser&timestamp=1234567890000",
+        )
+        assert resp.status_code == 401


### PR DESCRIPTION
## Summary
- New `GET /staging/drafts/{draft_id}/{filename}` endpoint serves uploaded files from delivery-kid staging
- Supports header auth (HMAC/API key/wallet) and query param auth (`?token=&user=&timestamp=`) for `<video src>` tags
- Path traversal protection, correct Content-Type, range request support for video seeking
- 7 new tests (20 total passing)

## Context
ReleaseDraft pages on PickiPedia need to embed video previews. The companion PR (pickipedia) renders a `<video>` tag that points to this endpoint with auth query params.

## Test plan
- [ ] `pytest tests/` passes (20 tests)
- [ ] Deploy to delivery-kid, verify `GET /staging/drafts/{uuid}/{file}` serves files with correct MIME type
- [ ] Verify range requests work (video seeking in browser)
- [ ] Verify auth rejection without valid token