### PR TITLE
Add video trim support to finalize pipeline

### DIFF
--- a/delivery-kid/pinning-service/app/models/content.py
+++ b/delivery-kid/pinning-service/app/models/content.py
@@ -64,3 +64,9 @@ class ContentFinalizeRequest(BaseModel):
         description="Output video heights for HLS transcoding, e.g. [1080, 720, 480]. "
                     "Default [720, 480]. Common values: 2160 (4K), 1080, 720, 480, 360."
     )
+    trim_start_seconds: Optional[float] = Field(
+        default=None, description="Start time in seconds for trimming the video"
+    )
+    trim_end_seconds: Optional[float] = Field(
+        default=None, description="End time in seconds for trimming the video"
+    )

--- a/delivery-kid/pinning-service/app/routes/content.py
+++ b/delivery-kid/pinning-service/app/routes/content.py
@@ -297,9 +297,14 @@ async def finalize_sse_generator(
             source_url = f"{settings.ipfs_gateway_url}/ipfs/{source_cid}"
             logger.info("[content:%s] Source pinned: %s", draft_id[:8], source_cid)
 
+            trim_msg = ""
+            if request.trim_start_seconds is not None or request.trim_end_seconds is not None:
+                s = request.trim_start_seconds or 0
+                e = request.trim_end_seconds
+                trim_msg = f" (trimming {s:.1f}s–{e:.1f}s)" if e else f" (trimming from {s:.1f}s)"
             yield await send_event("progress", {
                 "stage": "transcode",
-                "message": "Submitting to Coconut for AV1 transcoding...",
+                "message": f"Submitting to Coconut for AV1 transcoding{trim_msg}...",
                 "progress": 30
             })
 
@@ -314,6 +319,8 @@ async def finalize_sse_generator(
                     api_key=settings.coconut_api_key,
                     webhook_url=webhook_url,
                     qualities=request.transcoding_qualities,
+                    trim_start=request.trim_start_seconds,
+                    trim_end=request.trim_end_seconds,
                 )
                 coconut_job_id = coconut_result.get("id")
                 logger.info("[content:%s] Coconut job created: %s", draft_id[:8], coconut_job_id)
@@ -373,7 +380,11 @@ async def finalize_sse_generator(
             })
 
             hls_dir = output_dir / "hls"
-            result = await transcode.transcode_video_to_hls(src_path, hls_dir)
+            result = await transcode.transcode_video_to_hls(
+                src_path, hls_dir,
+                trim_start=request.trim_start_seconds,
+                trim_end=request.trim_end_seconds,
+            )
 
             if not result.success:
                 yield await send_event("error", {

--- a/delivery-kid/pinning-service/app/services/coconut.py
+++ b/delivery-kid/pinning-service/app/services/coconut.py
@@ -59,6 +59,8 @@ async def submit_to_coconut(
     api_key: str,
     webhook_url: str,
     qualities: list[int] | None = None,
+    trim_start: float | None = None,
+    trim_end: float | None = None,
 ) -> dict:
     """Submit a video to Coconut for AV1 HLS transcoding.
 
@@ -82,7 +84,7 @@ async def submit_to_coconut(
     outputs = {}
     for q in qualities:
         key = f"hls_av1_{q}p"
-        outputs[key] = {
+        output = {
             "path": f"/output/{q}p/playlist.m3u8",
             "video": {
                 "codec": "av1",
@@ -97,6 +99,14 @@ async def submit_to_coconut(
                 "segment_duration": 6,
             },
         }
+        # Coconut trim: offset (start seconds) + duration (length seconds)
+        if trim_start is not None:
+            output["offset"] = trim_start
+        if trim_start is not None and trim_end is not None:
+            output["duration"] = trim_end - trim_start
+        elif trim_end is not None:
+            output["duration"] = trim_end
+        outputs[key] = output
 
     # Master playlist
     outputs["hls_master"] = {

--- a/delivery-kid/pinning-service/app/services/transcode.py
+++ b/delivery-kid/pinning-service/app/services/transcode.py
@@ -136,7 +136,9 @@ async def transcode_album_directory(
 async def transcode_video_to_hls(
     input_path: Path,
     output_dir: Path,
-    progress_callback: Optional[Callable[[str], Awaitable[None]]] = None
+    progress_callback: Optional[Callable[[str], Awaitable[None]]] = None,
+    trim_start: Optional[float] = None,
+    trim_end: Optional[float] = None,
 ) -> TranscodeResult:
     """
     Transcode a video file to HLS (HTTP Live Streaming) format.
@@ -172,7 +174,20 @@ async def transcode_video_to_hls(
 
         cmd = [
             "ffmpeg", "-y",
+        ]
+        # Trim: -ss before -i for fast seek, -to after -i for end time
+        if trim_start is not None:
+            cmd.extend(["-ss", str(trim_start)])
+        cmd.extend([
             "-i", str(input_path),
+        ])
+        if trim_end is not None:
+            # -to is relative to -ss when -ss is before -i
+            if trim_start is not None:
+                cmd.extend(["-to", str(trim_end - trim_start)])
+            else:
+                cmd.extend(["-to", str(trim_end)])
+        cmd.extend([
             # Video: H.264 for broad compatibility
             "-c:v", "libx264",
             "-preset", "medium",
@@ -186,7 +201,7 @@ async def transcode_video_to_hls(
             "-hls_list_size", "0",  # Keep all segments in playlist
             "-hls_segment_filename", str(output_dir / "segment_%03d.ts"),
             str(master_playlist),
-        ]
+        ])
 
         process = await asyncio.create_subprocess_exec(
             *cmd,


### PR DESCRIPTION
## Summary
- Accept `trim_start_seconds` / `trim_end_seconds` in `ContentFinalizeRequest`
- Coconut path: applies as `offset` / `duration` on each HLS output variant
- Local ffmpeg fallback: applies as `-ss` (before `-i` for fast seek) and `-to`
- Progress message includes trim range when active

## Test plan
- [ ] Finalize a video draft with trim values set — verify Coconut receives offset/duration
- [ ] Finalize without trim — verify no offset/duration sent (backwards compat)
- [ ] Test local ffmpeg fallback with trim values