### PR TITLE
Background preview transcoding, preserve-original

### DIFF
--- a/delivery-kid/pinning-service/app/models/content.py
+++ b/delivery-kid/pinning-service/app/models/content.py
@@ -1,5 +1,6 @@
 """Pydantic models for general content drafts (video, audio, arbitrary files)."""
 
+import secrets
 from datetime import datetime
 from typing import Optional
 from pydantic import BaseModel, Field
@@ -35,6 +36,13 @@ class ContentDraftState(BaseModel):
     uploaded_by: str = Field(description="Wallet address that created the draft")
     files: list[ContentFile]
     metadata: dict = Field(default_factory=dict, description="User-supplied metadata")
+    # Preview transcoding (background, after upload)
+    preview_token: str = Field(default_factory=lambda: secrets.token_urlsafe(32),
+                               description="One-time token for Coconut to fetch source video from staging")
+    preview_status: str = Field(default="none", description="none, pending, processing, ready, failed")
+    preview_job_id: Optional[str] = Field(default=None, description="Coconut job ID for preview transcode")
+    preview_cid: Optional[str] = Field(default=None, description="IPFS CID of AV1 HLS output")
+    preview_mp4_cid: Optional[str] = Field(default=None, description="IPFS CID of 480p H.264 preview MP4")
 
 
 class ContentDraftResponse(BaseModel):
@@ -45,6 +53,9 @@ class ContentDraftResponse(BaseModel):
     files: list[ContentFile]
     metadata: dict = Field(default_factory=dict)
     commit: str = Field(default="unknown", description="Git commit hash of the build that created this draft")
+    preview_status: str = Field(default="none", description="none, pending, processing, ready, failed")
+    preview_cid: Optional[str] = Field(default=None, description="IPFS CID of AV1 HLS output")
+    preview_mp4_cid: Optional[str] = Field(default=None, description="IPFS CID of 480p preview MP4")
 
 
 class ContentFinalizeRequest(BaseModel):
@@ -69,4 +80,7 @@ class ContentFinalizeRequest(BaseModel):
     )
     trim_end_seconds: Optional[float] = Field(
         default=None, description="End time in seconds for trimming the video"
+    )
+    preserve_original: bool = Field(
+        default=False, description="Save the original source file to permanent storage instead of deleting it"
     )

--- a/delivery-kid/pinning-service/app/routes/coconut.py
+++ b/delivery-kid/pinning-service/app/routes/coconut.py
@@ -6,6 +6,7 @@ GET  /job/{job_id}        — check job status
 GET  /jobs                — list recent jobs
 """
 
+import json
 import logging
 import time
 from datetime import datetime, timezone
@@ -16,6 +17,7 @@ from pydantic import BaseModel
 
 from ..auth import require_auth
 from ..config import get_settings, Settings
+from ..models.content import ContentDraftState
 from ..services import ipfs
 from ..services.coconut import (
     submit_to_coconut,
@@ -28,6 +30,31 @@ from ..services.coconut import (
 logger = logging.getLogger(__name__)
 
 router = APIRouter(tags=["coconut"])
+
+
+def _update_draft_preview(staging_dir: Path, job: dict) -> None:
+    """Update a content draft's preview state after Coconut webhook."""
+    draft_id = job["draftId"]
+    draft_json = staging_dir / "drafts" / draft_id / "draft.json"
+    if not draft_json.exists():
+        logger.warning("[%s] Preview draft not found: %s", job["id"], draft_id)
+        return
+    try:
+        data = json.loads(draft_json.read_text())
+        if job["status"] == "complete" and job.get("hlsCid"):
+            data["preview_status"] = "ready"
+            data["preview_cid"] = job["hlsCid"]
+            # previewCid = 480p MP4 for the video player on the ReleaseDraft page
+            if job.get("previewCid"):
+                data["preview_mp4_cid"] = job["previewCid"]
+            logger.info("[%s] Draft %s preview ready: hls=%s mp4=%s",
+                        job["id"], draft_id[:8], job["hlsCid"], job.get("previewCid", "none"))
+        else:
+            data["preview_status"] = "failed"
+            logger.warning("[%s] Draft %s preview failed", job["id"], draft_id[:8])
+        draft_json.write_text(json.dumps(data, indent=2, default=str))
+    except Exception as e:
+        logger.error("[%s] Failed to update draft preview state: %s", job["id"], e)
 
 
 class TranscodeRequest(BaseModel):
@@ -174,6 +201,10 @@ async def webhook_coconut(request: Request, settings: Settings = Depends(get_set
             job["failedAt"] = datetime.now(timezone.utc).isoformat()
 
         save_job(staging_dir, job_id, job)
+
+        # If this is a preview job, update the draft state
+        if job.get("isPreview") and job.get("draftId"):
+            _update_draft_preview(staging_dir, job)
         return {"received": True}
 
     except Exception as e:

--- a/delivery-kid/pinning-service/app/routes/content.py
+++ b/delivery-kid/pinning-service/app/routes/content.py
@@ -2,7 +2,9 @@
 
 import asyncio
 import json
+import logging
 import shutil
+import time
 import uuid
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
@@ -16,7 +18,9 @@ from ..models.content import (
     ContentFile, ContentDraftState, ContentDraftResponse, ContentFinalizeRequest
 )
 from ..services import analyze, ipfs, transcode
-from ..services.coconut import submit_to_coconut, save_job
+from ..services.coconut import submit_to_coconut, save_job, load_job
+
+logger = logging.getLogger(__name__)
 
 router = APIRouter(prefix="/draft-content", tags=["content"])
 
@@ -138,6 +142,10 @@ async def create_content_draft(
         now = datetime.now(timezone.utc)
         expires_at = now + timedelta(hours=settings.draft_ttl_hours)
 
+        # Determine if this is a single-video upload that should get a preview
+        video_files = [f for f in draft_files if f.media_type == "video"]
+        should_preview = len(draft_files) == 1 and len(video_files) == 1 and settings.coconut_api_key
+
         state = ContentDraftState(
             draft_id=draft_id,
             draft_type="content",
@@ -145,14 +153,22 @@ async def create_content_draft(
             expires_at=expires_at,
             uploaded_by=wallet_address,
             files=draft_files,
+            preview_status="pending" if should_preview else "none",
         )
         save_draft_state(draft_dir, state)
+
+        # Kick off background preview transcoding for video uploads
+        if should_preview:
+            asyncio.create_task(
+                _submit_preview_transcode(draft_id, state, settings)
+            )
 
         return ContentDraftResponse(
             draft_id=draft_id,
             expires_at=expires_at,
             files=draft_files,
             commit=get_commit(),
+            preview_status=state.preview_status,
         )
 
     except HTTPException:
@@ -190,6 +206,9 @@ async def get_content_draft(
         files=state.files,
         metadata=state.metadata,
         commit=get_commit(),
+        preview_status=state.preview_status,
+        preview_cid=state.preview_cid,
+        preview_mp4_cid=state.preview_mp4_cid,
     )
 
 
@@ -212,6 +231,70 @@ async def delete_content_draft(
 
     shutil.rmtree(draft_dir)
     return {"message": "Draft deleted", "draft_id": draft_id}
+
+
+async def _submit_preview_transcode(
+    draft_id: str, state: ContentDraftState, settings: Settings
+) -> None:
+    """Background task: submit video to Coconut for AV1 HLS preview.
+
+    Coconut fetches the source from our staging endpoint via preview_token,
+    transcodes to AV1 HLS, and delivers via webhook. The webhook handler
+    pins the HLS output to IPFS and updates draft state with the CID.
+    """
+    staging_dir = Path(settings.staging_dir)
+    draft_dir = get_draft_dir(staging_dir, draft_id)
+
+    try:
+        video_file = state.files[0]
+
+        # Build the source URL: Coconut will fetch from our staging endpoint
+        # using the preview_token for auth (no IPFS pin of the original needed)
+        base_url = settings.ipfs_gateway_url.replace("ipfs.", "", 1)
+        source_url = (
+            f"{base_url}/staging/drafts/{draft_id}/{video_file.original_filename}"
+            f"?preview_token={state.preview_token}"
+        )
+
+        # Build webhook URL — reuses existing /webhook/coconut handler
+        job_id = f"preview-{draft_id[:12]}-{int(time.time())}"
+        webhook_url = f"{base_url}/webhook/coconut?job_id={job_id}"
+
+        logger.info("[preview:%s] Submitting to Coconut, source=%s", draft_id[:8], source_url[:80])
+
+        coconut_result = await submit_to_coconut(
+            source_url=source_url,
+            api_key=settings.coconut_api_key,
+            webhook_url=webhook_url,
+            include_preview=True,
+        )
+        coconut_job_id = coconut_result.get("id")
+        logger.info("[preview:%s] Coconut job created: %s", draft_id[:8], coconut_job_id)
+
+        # Save job state for the webhook handler
+        job_state = {
+            "id": job_id,
+            "coconutJobId": coconut_job_id,
+            "status": "processing",
+            "draftId": draft_id,
+            "isPreview": True,
+            "createdAt": datetime.now(timezone.utc).isoformat(),
+            "identity": state.uploaded_by,
+        }
+        save_job(staging_dir, job_id, job_state)
+
+        # Update draft state
+        state.preview_status = "processing"
+        state.preview_job_id = job_id
+        save_draft_state(draft_dir, state)
+
+    except Exception as e:
+        logger.error("[preview:%s] Failed to submit preview: %s", draft_id[:8], e)
+        try:
+            state.preview_status = "failed"
+            save_draft_state(draft_dir, state)
+        except Exception:
+            pass
 
 
 def _should_use_coconut(request: ContentFinalizeRequest, settings: Settings) -> bool:
@@ -247,18 +330,16 @@ async def finalize_sse_generator(
 ):
     """SSE generator for content finalization — transcode if needed, then pin.
 
-    For video with transcoding enabled:
-    - Tries Coconut.co cloud transcoding first (AV1+Opus HLS, async via webhook)
-    - Falls back to local ffmpeg if Coconut is unavailable
-    - Coconut path: pins source to IPFS, submits job, returns job_id for polling
-    - Local path: synchronous transcode via SSE progress events
-    """
-    import logging
-    import time
-    logger = logging.getLogger(__name__)
+    Fast path: if preview transcoding already produced an HLS CID and no trim
+    is requested, finalization is instant — just emit the existing CID.
 
+    Slow path (trim requested or no preview): Coconut cloud transcoding first,
+    local ffmpeg fallback. Coconut fetches source from staging via preview_token.
+    """
     async def send_event(event: str, data: dict):
         return {"event": event, "data": json.dumps(data)}
+
+    has_trim = request.trim_start_seconds is not None or request.trim_end_seconds is not None
 
     try:
         upload_dir = draft_dir / "upload"
@@ -271,34 +352,53 @@ async def finalize_sse_generator(
             "progress": 5
         })
 
+        # Preserve original file if requested
+        if request.preserve_original:
+            originals_dir = Path(settings.staging_dir) / "originals" / draft_id
+            originals_dir.mkdir(parents=True, exist_ok=True)
+            for f in state.files:
+                src = upload_dir / f.original_filename
+                if src.exists():
+                    shutil.copy2(src, originals_dir / f.original_filename)
+            logger.info("[content:%s] Original files preserved to %s", draft_id[:8], originals_dir)
+
         video_files = [f for f in state.files if f.media_type == "video"]
         wants_transcode = len(state.files) == 1 and video_files and _should_transcode_video(request)
 
+        # === Fast path: preview already done, no trim ===
+        if wants_transcode and state.preview_cid and not has_trim:
+            logger.info("[content:%s] Using existing preview HLS: %s", draft_id[:8], state.preview_cid)
+            yield await send_event("progress", {
+                "stage": "transcode",
+                "message": "AV1 HLS already transcoded — using preview.",
+                "progress": 80
+            })
+
+            gateway_url = f"{settings.ipfs_gateway_url}/ipfs/{state.preview_cid}"
+
+            yield await send_event("complete", {
+                "cid": state.preview_cid,
+                "gateway_url": gateway_url,
+                "title": request.title,
+                "file_type": request.file_type,
+                "subsequent_to": request.subsequent_to,
+            })
+            return
+
+        # === Coconut cloud transcoding (with trim, or no preview available) ===
         if wants_transcode and _should_use_coconut(request, settings):
-            # === Coconut cloud transcoding path (async) ===
             video_file = video_files[0]
             src_path = upload_dir / video_file.original_filename
 
-            yield await send_event("progress", {
-                "stage": "ipfs",
-                "message": "Pinning source video to IPFS...",
-                "progress": 10
-            })
-
-            # Pin source to IPFS so Coconut can fetch it via gateway
-            pin_result = await ipfs.add_file(src_path)
-            if not pin_result.success:
-                yield await send_event("error", {
-                    "message": f"Failed to pin source video: {pin_result.error}"
-                })
-                return
-
-            source_cid = pin_result.cid
-            source_url = f"{settings.ipfs_gateway_url}/ipfs/{source_cid}"
-            logger.info("[content:%s] Source pinned: %s", draft_id[:8], source_cid)
+            # Build source URL — Coconut fetches from staging via preview_token
+            base_url = settings.ipfs_gateway_url.replace("ipfs.", "", 1)
+            source_url = (
+                f"{base_url}/staging/drafts/{draft_id}/{video_file.original_filename}"
+                f"?preview_token={state.preview_token}"
+            )
 
             trim_msg = ""
-            if request.trim_start_seconds is not None or request.trim_end_seconds is not None:
+            if has_trim:
                 s = request.trim_start_seconds or 0
                 e = request.trim_end_seconds
                 trim_msg = f" (trimming {s:.1f}s–{e:.1f}s)" if e else f" (trimming from {s:.1f}s)"
@@ -308,8 +408,6 @@ async def finalize_sse_generator(
                 "progress": 30
             })
 
-            # Build webhook URL
-            base_url = settings.ipfs_gateway_url.replace("ipfs.", "", 1)
             job_id = f"coconut-{int(time.time())}-{id(src_path) % 100000:05d}"
             webhook_url = f"{base_url}/webhook/coconut?job_id={job_id}"
 
@@ -325,13 +423,11 @@ async def finalize_sse_generator(
                 coconut_job_id = coconut_result.get("id")
                 logger.info("[content:%s] Coconut job created: %s", draft_id[:8], coconut_job_id)
 
-                # Save job state for webhook handler
                 job_state = {
                     "id": job_id,
                     "coconutJobId": coconut_job_id,
                     "status": "processing",
-                    "sourceCid": source_cid,
-                    "keepOriginal": False,
+                    "keepOriginal": request.preserve_original,
                     "title": request.title,
                     "fileType": request.file_type,
                     "subsequentTo": request.subsequent_to,
@@ -340,16 +436,14 @@ async def finalize_sse_generator(
                 }
                 save_job(Path(settings.staging_dir), job_id, job_state)
 
-                # Clean up draft dir — source is on IPFS now
-                shutil.rmtree(draft_dir, ignore_errors=True)
+                # Don't delete draft dir yet — source file still needed if Coconut
+                # hasn't fetched it. Draft TTL cleanup handles it.
 
                 yield await send_event("transcoding-submitted", {
-                    "sourceCid": source_cid,
                     "jobId": job_id,
                     "coconutJobId": coconut_job_id,
                     "message": "Video submitted for AV1 cloud transcoding. HLS output will be pinned automatically when complete.",
                     "pollUrl": f"/job/{job_id}",
-                    "gatewayUrl": f"{settings.ipfs_gateway_url}/ipfs/{source_cid}",
                     "title": request.title,
                     "fileType": request.file_type,
                     "subsequentTo": request.subsequent_to,
@@ -366,7 +460,6 @@ async def finalize_sse_generator(
                     "message": "Cloud transcoding unavailable, using local ffmpeg...",
                     "progress": 15
                 })
-                # Fall through to local transcoding below
 
         if wants_transcode:
             # === Local ffmpeg transcoding path (sync) ===

--- a/delivery-kid/pinning-service/app/routes/staging.py
+++ b/delivery-kid/pinning-service/app/routes/staging.py
@@ -20,6 +20,7 @@ from fastapi.responses import FileResponse
 
 from ..auth import require_auth, verify_upload_token
 from ..config import get_settings, Settings
+from ..models.content import ContentDraftState
 
 router = APIRouter(prefix="/staging", tags=["staging"])
 
@@ -36,55 +37,61 @@ for _ext, _mime in _MEDIA_TYPES.items():
     mimetypes.add_type(_mime, _ext)
 
 
-async def require_staging_auth(
-    request: Request,
-    token: Optional[str] = Query(None),
-    user: Optional[str] = Query(None),
-    timestamp: Optional[str] = Query(None),
-    settings: Settings = Depends(get_settings),
-) -> str:
-    """Authenticate via headers (standard) or query params (for <video src>).
-
-    Query param auth uses the same HMAC verification as header auth,
-    just sourced from ?token=&user=&timestamp= instead of X-Upload-* headers.
-    """
-    # Try header auth first (X-Upload-Token, X-API-Key, or X-Signature).
-    # If it fails, fall through to query param auth below.
+def _check_preview_token(draft_id: str, preview_token: str, settings: Settings) -> bool:
+    """Validate a preview_token against the draft state on disk."""
+    import json
+    draft_json = Path(settings.staging_dir) / "drafts" / draft_id / "draft.json"
+    if not draft_json.exists():
+        return False
     try:
-        return await require_auth(request, settings)
-    except HTTPException:
-        pass
+        data = json.loads(draft_json.read_text())
+        return data.get("preview_token") == preview_token and preview_token
+    except (json.JSONDecodeError, OSError):
+        return False
 
-    # Fall back to query param auth
-    if token and user and timestamp:
-        try:
-            ts = int(timestamp)
-        except (ValueError, TypeError):
-            raise HTTPException(status_code=401, detail="Invalid timestamp")
-
-        if verify_upload_token(token, user, ts, settings, action="upload"):
-            return f"wiki:{user}"
-
-    raise HTTPException(
-        status_code=401,
-        detail="Authentication required (via headers or query params)"
-    )
 
 
 @router.get("/drafts/{draft_id}/{filename}")
 async def get_staging_file(
     draft_id: str,
     filename: str,
-    identity: str = Depends(require_staging_auth),
+    request: Request,
+    token: Optional[str] = Query(None),
+    user: Optional[str] = Query(None),
+    timestamp: Optional[str] = Query(None),
+    preview_token: Optional[str] = Query(None),
     settings: Settings = Depends(get_settings),
 ):
     """Serve a file from a staging draft for preview.
 
     Used by the ReleaseDraft page to embed video/audio players.
+    Also used by Coconut to fetch source video for transcoding (via preview_token).
+
+    Auth: HMAC headers, HMAC query params, or preview_token query param.
     """
     # Sanitize path components to prevent traversal
     if ".." in draft_id or "/" in draft_id or ".." in filename or "/" in filename:
         raise HTTPException(status_code=400, detail="Invalid path")
+
+    # Auth: preview_token (for Coconut), then headers, then HMAC query params
+    authenticated = False
+    if preview_token and _check_preview_token(draft_id, preview_token, settings):
+        authenticated = True
+    if not authenticated:
+        try:
+            await require_auth(request, settings)
+            authenticated = True
+        except HTTPException:
+            pass
+    if not authenticated and token and user and timestamp:
+        try:
+            ts = int(timestamp)
+        except (ValueError, TypeError):
+            raise HTTPException(status_code=401, detail="Invalid timestamp")
+        if verify_upload_token(token, user, ts, settings, action="upload"):
+            authenticated = True
+    if not authenticated:
+        raise HTTPException(status_code=401, detail="Authentication required")
 
     file_path = Path(settings.staging_dir) / "drafts" / draft_id / "upload" / filename
 

--- a/delivery-kid/pinning-service/app/services/coconut.py
+++ b/delivery-kid/pinning-service/app/services/coconut.py
@@ -61,6 +61,7 @@ async def submit_to_coconut(
     qualities: list[int] | None = None,
     trim_start: float | None = None,
     trim_end: float | None = None,
+    include_preview: bool = False,
 ) -> dict:
     """Submit a video to Coconut for AV1 HLS transcoding.
 
@@ -116,6 +117,28 @@ async def submit_to_coconut(
             "variants": [f"hls_av1_{q}p" for q in qualities],
         },
     }
+
+    # Optional 480p H.264 preview MP4 — lightweight, plays natively in all browsers
+    if include_preview:
+        preview_output = {
+            "path": "/output/preview.mp4",
+            "video": {
+                "codec": "h264",
+                "height": 480,
+                "bitrate": "800k",
+            },
+            "audio": {
+                "codec": "aac",
+                "bitrate": "96k",
+            },
+        }
+        if trim_start is not None:
+            preview_output["offset"] = trim_start
+        if trim_start is not None and trim_end is not None:
+            preview_output["duration"] = trim_end - trim_start
+        elif trim_end is not None:
+            preview_output["duration"] = trim_end
+        outputs["mp4_preview"] = preview_output
 
     job_config = {
         "input": {"url": source_url},
@@ -208,9 +231,10 @@ async def process_completed_job(
     ipfs_api_url: str,
     pinata_jwt: str = "",
 ) -> Optional[str]:
-    """Process a completed Coconut job: download HLS, pin to IPFS.
+    """Process a completed Coconut job: download HLS + preview, pin to IPFS.
 
     Returns the HLS directory CID, or None on failure.
+    Also pins the preview MP4 if present and stores its CID in job["previewCid"].
     """
     job_id = job["id"]
     hls_dir = staging_dir / f"hls-{job_id}"
@@ -219,7 +243,27 @@ async def process_completed_job(
         # Download all HLS outputs
         await download_hls_outputs(outputs, hls_dir)
 
-        # Pin to IPFS
+        # Download preview MP4 if present
+        preview_output = outputs.get("mp4_preview", {})
+        preview_url = preview_output.get("url")
+        if preview_url:
+            preview_path = staging_dir / f"preview-{job_id}.mp4"
+            try:
+                async with httpx.AsyncClient(timeout=120.0) as client:
+                    resp = await client.get(preview_url)
+                    if resp.is_success:
+                        preview_path.write_bytes(resp.content)
+                        logger.info("[%s] Preview MP4 downloaded (%d bytes)", job_id, len(resp.content))
+                        # Pin preview to IPFS
+                        preview_result = await ipfs.add_file(preview_path)
+                        if preview_result.success:
+                            job["previewCid"] = preview_result.cid
+                            logger.info("[%s] Preview pinned: %s", job_id, preview_result.cid)
+                        preview_path.unlink(missing_ok=True)
+            except Exception as e:
+                logger.warning("[%s] Preview download/pin failed: %s", job_id, e)
+
+        # Pin HLS to IPFS
         logger.info("[%s] Pinning HLS directory to IPFS...", job_id)
         result = await ipfs.add_directory(hls_dir)
 


### PR DESCRIPTION
## Summary
- After video upload, automatically submit to Coconut for AV1 HLS + 480p H.264 preview transcoding in the background
- Coconut fetches source from staging via `preview_token` — original is never pinned to IPFS (stays private until finalized)
- Fast-path finalize: if preview HLS is ready and no trim requested, finalization is instant (no re-transcode)
- `preserve_original` option copies source files to `/staging/originals/{draft_id}/` before cleanup
- Staging endpoint accepts `preview_token` query param for unauthenticated Coconut access

## Test plan
- [ ] Upload a video → preview_status starts as "pending"
- [ ] Poll draft API → transitions to "processing" then "ready"
- [ ] Finalize without trim → instant complete (uses existing preview CID)
- [ ] Finalize with trim → re-submits to Coconut with offset/duration
- [ ] preserve_original checkbox → original saved to /staging/originals/