### PR TITLE
Add Godot 4 and godogen skills to hunter containers

### DIFF
--- a/hunter/Dockerfile
+++ b/hunter/Dockerfile
@@ -66,6 +66,20 @@ RUN (type -p wget >dev/null || (apt update && apt install wget -y)) \
     && apt update \
     && apt install gh -y
 
+# Install Godot 4 (headless-compatible binary for game development)
+RUN GODOT_VERSION=$(curl -s https://api.github.com/repos/godotengine/godot/releases/latest | grep -oP '"tag_name": "\K[^"]+' | sed 's/-stable//') \
+    && echo "Installing Godot ${GODOT_VERSION}" \
+    && cd /tmp \
+    && wget -q "https://github.com/godotengine/godot/releases/download/${GODOT_VERSION}-stable/Godot_v${GODOT_VERSION}-stable_linux.x86_64.zip" \
+    && unzip -q Godot_v${GODOT_VERSION}-stable_linux.x86_64.zip \
+    && mv Godot_v${GODOT_VERSION}-stable_linux.x86_64 /usr/local/bin/godot \
+    && chmod +x /usr/local/bin/godot \
+    && rm -f Godot_v${GODOT_VERSION}-stable_linux.x86_64.zip \
+    && (godot --headless --version || echo "Godot installed (version check skipped)")
+
+# Clone godogen (Claude Code skills for Godot game generation)
+RUN git clone --depth 1 https://github.com/htdt/godogen.git /opt/godogen
+
 USER magent
 WORKDIR /home/magent
 
@@ -104,6 +118,12 @@ ENV PATH="/root/.local/bin:$PATH"
 
 # Install Python dependencies for memory-lane using uv
 RUN /root/.local/bin/uv pip install --python /usr/bin/python3 --break-system-packages -r /home/magent/workspace/memory-lane/requirements.txt
+
+# Install godogen Python dependencies (rembg, etc. for Godot asset pipeline)
+# Skip GPU-specific packages (onnxruntime-gpu, nvidia-cudnn) since hunter has no NVIDIA GPU
+# Install CPU onnxruntime instead
+RUN /root/.local/bin/uv pip install --python /usr/bin/python3 --break-system-packages \
+    google-genai xai-sdk requests numpy pillow rembg pymatting onnxruntime
 
 # Copy startup script
 COPY container_startup.py /usr/local/bin/

--- a/hunter/container_startup.py
+++ b/hunter/container_startup.py
@@ -521,6 +521,37 @@ def start_pickipedia_preview():
     logger.info(f"✓ PickiPedia preview ready at: https://pickipedia.{dev_name}.hunter.cryptograss.live")
 
 
+def setup_godot():
+    """Set up Godot game development workspace with godogen skills."""
+    logger.info("=== Setting up Godot development environment ===")
+
+    games_dir = Path("/home/magent/workspace/games")
+
+    # Only set up if godogen is available and games dir doesn't exist yet
+    godogen_dir = Path("/opt/godogen")
+    if not godogen_dir.exists():
+        logger.warning("godogen not found at /opt/godogen, skipping Godot setup")
+        return
+
+    if games_dir.exists():
+        logger.info("✓ Godot games workspace already exists")
+        return
+
+    # Publish godogen skills to a new game project directory
+    logger.info("Publishing godogen skills to games workspace...")
+    games_dir.mkdir(parents=True, exist_ok=True)
+    run_command(f"chown magent:magent {games_dir}")
+    run_command(f"bash /opt/godogen/publish.sh {games_dir}", user='magent')
+    logger.info("✓ Godot games workspace ready at ~/workspace/games")
+
+    # Verify Godot is available
+    result = run_command("godot --version", check=False)
+    if result.returncode == 0:
+        logger.info(f"✓ Godot available: {result.stdout.strip()}")
+    else:
+        logger.warning("⚠ Godot binary not responding (may need display for full init)")
+
+
 def start_services():
     """Start required services."""
     logger.info("=== Starting services ===")
@@ -557,6 +588,7 @@ def main():
         configure_github_cli()
         configure_mcp_server()
         configure_claude_settings()
+        setup_godot()
         start_services()
 
         logger.info("=" * 60)

--- a/hunter/packages.txt
+++ b/hunter/packages.txt
@@ -42,3 +42,7 @@ imagemagick
 jp2a
 caca-utils
 libaa-bin
+mesa-utils
+ffmpeg
+unzip
+wget


### PR DESCRIPTION
## Summary

- Install Godot 4 engine binary (latest stable) into hunter containers at `/usr/local/bin/godot`
- Clone [htdt/godogen](https://github.com/htdt/godogen) to `/opt/godogen` — Claude Code skills for Godot game dev (GDScript reference, scene generation, quirks database, visual QA)
- Install Python dependencies for godogen's asset pipeline (rembg, pillow, onnxruntime CPU-only)
- Add `mesa-utils`, `ffmpeg`, `unzip`, `wget` to system packages
- New `setup_godot()` in container startup publishes godogen skills to `~/workspace/games` on first boot

Motivated by [this HN discussion](https://news.ycombinator.com/item?id=47400868) on using Claude Code skills for Godot game generation.

## Test plan

- [ ] Docker image builds successfully with Godot binary present
- [ ] `godot --headless --version` works inside container
- [ ] godogen Python deps install without GPU errors (CPU onnxruntime only)
- [ ] Container startup creates `~/workspace/games/` with `.claude/skills/` on first boot
- [ ] `/godogen` skill available in Claude Code when working in games directory