### PR TITLE
Add SMW rebuildData to pickipedia deploy

### DIFF
--- a/pickipedia-vps/ansible/roles/docker-wiki/tasks/main.yml
+++ b/pickipedia-vps/ansible/roles/docker-wiki/tasks/main.yml
@@ -95,3 +95,10 @@
   until: wiki_health.status in [200, 301, 302, 404]
   retries: 15
   delay: 2
+
+- name: Rebuild Semantic MediaWiki data
+  command:
+    cmd: docker exec pickipedia-wiki php /var/www/html/maintenance/run.php SMW\Maintenance\RebuildData
+  register: smw_rebuild
+  failed_when: false
+  changed_when: smw_rebuild.rc == 0


### PR DESCRIPTION
## Summary
- Runs `SMW\Maintenance\RebuildData` after the wiki container is healthy during deploy
- Ensures semantic properties are always indexed after code changes
- `failed_when: false` so a missing SMW extension won't break the deploy

## Test plan
- [ ] Run `deploy-pickipedia-remote.py` and verify SMW rebuild runs in the Ansible output
- [ ] Check `Special:Browse` on a Release page to confirm properties appear