### PR TITLE
Allow finalize-release users to view any draft on delivery-kid

### DIFF
--- a/delivery-kid/pinning-service/app/auth.py
+++ b/delivery-kid/pinning-service/app/auth.py
@@ -195,10 +195,23 @@ async def require_auth(
 
     Returns an identity string.
     """
-    # 1. HMAC upload token (wiki-issued, for direct browser uploads)
-    identity = _verify_hmac_headers(request, settings, action="upload")
-    if identity:
-        return identity
+    # 1. HMAC token (wiki-issued — accept either upload or finalize prefix,
+    #    both prove the user is authenticated via the wiki)
+    upload_token = request.headers.get("X-Upload-Token")
+    if upload_token:
+        username = request.headers.get("X-Upload-User", "")
+        timestamp_str = request.headers.get("X-Upload-Timestamp", "")
+        try:
+            timestamp = int(timestamp_str)
+        except (ValueError, TypeError):
+            raise HTTPException(status_code=401, detail={"error": "Invalid upload timestamp"})
+
+        if verify_upload_token(upload_token, username, timestamp, settings, action="upload"):
+            return f"wiki:{username}"
+        if verify_upload_token(upload_token, username, timestamp, settings, action="finalize"):
+            return f"wiki:{username}"
+
+        raise HTTPException(status_code=401, detail={"error": "Invalid or expired token"})
 
     # 2. API key (server-to-server)
     api_key = request.headers.get("X-API-Key")
@@ -217,6 +230,25 @@ async def require_auth(
 
     # 3. Wallet signature
     return await require_wallet_auth(request, settings)
+
+
+def has_finalize_token(request: Request, settings: Settings) -> bool:
+    """Check if the request carries a valid finalize-prefixed HMAC token.
+
+    Non-throwing — returns False if absent, invalid, or mismatched.
+    Use this to grant elevated access (e.g. viewing other users' drafts)
+    without requiring finalize auth.
+    """
+    upload_token = request.headers.get("X-Upload-Token")
+    if not upload_token:
+        return False
+    username = request.headers.get("X-Upload-User", "")
+    timestamp_str = request.headers.get("X-Upload-Timestamp", "")
+    try:
+        timestamp = int(timestamp_str)
+    except (ValueError, TypeError):
+        return False
+    return verify_upload_token(upload_token, username, timestamp, settings, action="finalize")
 
 
 async def require_finalize_auth(

--- a/delivery-kid/pinning-service/app/routes/content.py
+++ b/delivery-kid/pinning-service/app/routes/content.py
@@ -209,10 +209,14 @@ async def get_content_draft(
 @router.delete("/{draft_id}")
 async def delete_content_draft(
     draft_id: str,
+    request: Request,
     wallet_address: str = Depends(require_auth),
     settings: Settings = Depends(get_settings)
 ):
-    """Delete a content draft and clean up files."""
+    """Delete a content draft and clean up files.
+
+    Accessible by the original uploader OR any user with finalize-release.
+    """
     staging_dir = Path(settings.staging_dir)
     draft_dir = get_draft_dir(staging_dir, draft_id)
 
@@ -220,7 +224,8 @@ async def delete_content_draft(
     if state is None:
         raise HTTPException(status_code=404, detail="Content draft not found")
 
-    if state.uploaded_by.lower() != wallet_address.lower():
+    is_owner = state.uploaded_by.lower() == wallet_address.lower()
+    if not is_owner and not has_finalize_token(request, settings):
         raise HTTPException(status_code=403, detail="Not your draft")
 
     shutil.rmtree(draft_dir)
@@ -578,8 +583,8 @@ async def finalize_content_draft(
     if state is None:
         raise HTTPException(status_code=404, detail="Content draft not found")
 
-    if state.uploaded_by.lower() != wallet_address.lower():
-        raise HTTPException(status_code=403, detail="Not your draft")
+    # No ownership check — require_finalize_auth already ensures
+    # the user has finalize-release permission.
 
     return EventSourceResponse(
         finalize_sse_generator(draft_id, request, draft_dir, state, settings),

--- a/delivery-kid/pinning-service/app/routes/content.py
+++ b/delivery-kid/pinning-service/app/routes/content.py
@@ -9,10 +9,10 @@ import uuid
 from datetime import datetime, timezone
 from pathlib import Path
 
-from fastapi import APIRouter, Depends, File, UploadFile, HTTPException
+from fastapi import APIRouter, Depends, File, Request, UploadFile, HTTPException
 from sse_starlette.sse import EventSourceResponse
 
-from ..auth import require_auth, require_finalize_auth
+from ..auth import require_auth, require_finalize_auth, has_finalize_token
 from ..config import get_settings, get_commit, Settings
 from ..models.content import (
     ContentFile, ContentDraftState, ContentDraftResponse, ContentFinalizeRequest
@@ -175,10 +175,15 @@ async def create_content_draft(
 @router.get("/{draft_id}", response_model=ContentDraftResponse)
 async def get_content_draft(
     draft_id: str,
+    request: Request,
     wallet_address: str = Depends(require_auth),
     settings: Settings = Depends(get_settings)
 ):
-    """Retrieve content draft state by ID."""
+    """Retrieve content draft state by ID.
+
+    Accessible by the original uploader OR any user with finalize-release
+    permission (indicated by a valid finalize-prefixed HMAC token).
+    """
     staging_dir = Path(settings.staging_dir)
     draft_dir = get_draft_dir(staging_dir, draft_id)
 
@@ -186,7 +191,8 @@ async def get_content_draft(
     if state is None:
         raise HTTPException(status_code=404, detail="Content draft not found")
 
-    if state.uploaded_by.lower() != wallet_address.lower():
+    is_owner = state.uploaded_by.lower() == wallet_address.lower()
+    if not is_owner and not has_finalize_token(request, settings):
         raise HTTPException(status_code=403, detail="Not your draft")
 
     return ContentDraftResponse(

--- a/delivery-kid/pinning-service/app/routes/drafts.py
+++ b/delivery-kid/pinning-service/app/routes/drafts.py
@@ -7,10 +7,10 @@ import uuid
 from datetime import datetime, timezone
 from pathlib import Path
 
-from fastapi import APIRouter, Depends, File, UploadFile, HTTPException
+from fastapi import APIRouter, Depends, File, Request, UploadFile, HTTPException
 from sse_starlette.sse import EventSourceResponse
 
-from ..auth import require_auth, require_finalize_auth
+from ..auth import require_auth, require_finalize_auth, has_finalize_token
 from ..config import get_settings, get_commit, Settings
 from ..models.draft import DraftFile, DraftState, DraftResponse, FinalizeRequest
 from ..services import analyze, ipfs, transcode
@@ -151,13 +151,14 @@ async def create_draft(
 @router.get("/{draft_id}", response_model=DraftResponse)
 async def get_draft(
     draft_id: str,
+    request: Request,
     wallet_address: str = Depends(require_auth),
     settings: Settings = Depends(get_settings)
 ):
     """
     Retrieve draft state by ID.
 
-    Useful for recovering state after page refresh.
+    Accessible by the original uploader OR any user with finalize-release.
     """
     staging_dir = Path(settings.staging_dir)
     draft_dir = get_draft_dir(staging_dir, draft_id)
@@ -166,8 +167,8 @@ async def get_draft(
     if state is None:
         raise HTTPException(status_code=404, detail="Draft not found")
 
-    # Verify ownership
-    if state.uploaded_by.lower() != wallet_address.lower():
+    is_owner = state.uploaded_by.lower() == wallet_address.lower()
+    if not is_owner and not has_finalize_token(request, settings):
         raise HTTPException(status_code=403, detail="Not your draft")
 
     return DraftResponse(
@@ -180,13 +181,14 @@ async def get_draft(
 @router.delete("/{draft_id}")
 async def delete_draft(
     draft_id: str,
+    request: Request,
     wallet_address: str = Depends(require_auth),
     settings: Settings = Depends(get_settings)
 ):
     """
     Delete a draft and cleanup files.
 
-    Use this to cancel an upload before finalization.
+    Accessible by the original uploader OR any user with finalize-release.
     """
     staging_dir = Path(settings.staging_dir)
     draft_dir = get_draft_dir(staging_dir, draft_id)
@@ -195,8 +197,8 @@ async def delete_draft(
     if state is None:
         raise HTTPException(status_code=404, detail="Draft not found")
 
-    # Verify ownership
-    if state.uploaded_by.lower() != wallet_address.lower():
+    is_owner = state.uploaded_by.lower() == wallet_address.lower()
+    if not is_owner and not has_finalize_token(request, settings):
         raise HTTPException(status_code=403, detail="Not your draft")
 
     # Cleanup
@@ -514,9 +516,8 @@ async def finalize_draft(
     if state is None:
         raise HTTPException(status_code=404, detail="Draft not found")
 
-    # Verify ownership
-    if state.uploaded_by.lower() != wallet_address.lower():
-        raise HTTPException(status_code=403, detail="Not your draft")
+    # No ownership check — require_finalize_auth already ensures
+    # the user has finalize-release permission.
 
     # Validate all requested files exist in draft
     draft_filenames = {f.original_filename for f in state.files}


### PR DESCRIPTION
## Summary
- Draft GET endpoint now allows access if user is the original uploader **OR** has a valid finalize token (release/sysop group)
- `require_auth()` accepts either upload or finalize tokens — both prove wiki authentication
- Fixes: logged-in users with finalize-release permission couldn't preview drafts uploaded by others

## Test plan
- [ ] Redeploy delivery-kid
- [ ] Log in as a finalize-release user, view a draft uploaded by someone else — preview should load
- [ ] Log in as a regular user, view someone else's draft — should still get 403
- [ ] Original uploader can still view their own draft