### PR TITLE
Remove draft auto-cleanup, extend token lifetime to 30 days

### DIFF
--- a/delivery-kid/pinning-service/app/config.py
+++ b/delivery-kid/pinning-service/app/config.py
@@ -30,7 +30,7 @@ class Settings(BaseSettings):
     coconut_api_key: str = ""
 
     # Auth settings
-    max_timestamp_drift_seconds: int = 3600  # 1 hour — token generated at page load, user may browse before uploading
+    max_timestamp_drift_seconds: int = 30 * 24 * 3600  # 30 days — tokens are checked on draft pages that may be revisited long after creation
     api_key: str = ""  # Shared API key for server-to-server auth (e.g., from PickiPedia)
 
     # Upload limits

--- a/delivery-kid/pinning-service/app/main.py
+++ b/delivery-kid/pinning-service/app/main.py
@@ -10,7 +10,6 @@ from fastapi.middleware.cors import CORSMiddleware
 
 from .config import get_settings
 from .routes import health, albums, drafts, content, enrich, torrent, coconut, staging
-from .services import cleanup
 from .services.seeder import init_seeder, stop_seeder
 
 # Configure logging
@@ -40,14 +39,6 @@ async def lifespan(app: FastAPI):
     staging_dir.mkdir(parents=True, exist_ok=True)
     (staging_dir / "drafts").mkdir(exist_ok=True)
 
-    # Run startup cleanup
-    cleanup.startup_cleanup(staging_dir)
-
-    # Start periodic cleanup task
-    cleanup_task = asyncio.create_task(
-        cleanup.periodic_cleanup(staging_dir, interval_seconds=3600)
-    )
-
     # Start BitTorrent seeder
     init_seeder(settings.seeding_dir)
 
@@ -56,13 +47,6 @@ async def lifespan(app: FastAPI):
 
     # Shutdown: stop seeder first
     stop_seeder()
-
-    # Cancel cleanup task
-    cleanup_task.cancel()
-    try:
-        await cleanup_task
-    except asyncio.CancelledError:
-        pass
     logger.info("Delivery Kid pinning service stopped")
 
 


### PR DESCRIPTION
## Summary
- Remove `startup_cleanup` and `periodic_cleanup` entirely from the application lifecycle — drafts persist until explicitly finalized or deleted, no automatic removal
- Extend HMAC token drift from 1 hour to 30 days — fixes 401 errors when returning to draft pages after the token generated at page load has expired

## Test plan
- [ ] Redeploy delivery-kid
- [ ] Visit a draft page that previously 401'd — should load
- [ ] Verify drafts are not cleaned up after restart