### PR TITLE
ansible: cap Docker BuildKit cache at 3GB after every build

### DIFF
--- a/delivery-kid/ansible/playbook.yml
+++ b/delivery-kid/ansible/playbook.yml
@@ -186,6 +186,13 @@
         state: present
         recreate: "{{ 'always' if (rebuild_images | default(false) | bool) else 'auto' }}"
 
+    # Cap BuildKit cache so repeated --rebuild / build:always deploys don't
+    # accumulate (we hit a 28GB / 337-entry cache on 2026-05-30 that took
+    # the host to 100% disk and killed the next deploy). -f prunes dangling
+    # cache only — active layers stay reusable; --keep-storage caps total.
+    - name: Cap Docker BuildKit cache at 3GB
+      command: docker builder prune -f --keep-storage 3GB
+
     # Wait for IPFS container to be running (not API - that won't work until configured)
     - name: Wait for IPFS container to start
       command: docker inspect -f '{% raw %}{{.State.Running}}{% endraw %}' ipfs

--- a/hunter/ansible/roles/build-image/tasks/main.yml
+++ b/hunter/ansible/roles/build-image/tasks/main.yml
@@ -51,3 +51,9 @@
   command: docker images magenta-arthel:latest --format "{% raw %}{{.Repository}}:{{.Tag}}{% endraw %}"
   register: image_check
   failed_when: "'magenta-arthel:latest' not in image_check.stdout"
+
+# Cap BuildKit cache so repeated rebuilds (especially the periodic base-image
+# bumps) don't accumulate unbounded. -f prunes dangling cache only —
+# active layers stay reusable; --keep-storage caps total at 3GB.
+- name: Cap Docker BuildKit cache at 3GB
+  command: docker builder prune -f --keep-storage 3GB

--- a/pickipedia-vps/ansible/roles/docker-wiki/handlers/main.yml
+++ b/pickipedia-vps/ansible/roles/docker-wiki/handlers/main.yml
@@ -6,5 +6,5 @@
 
 - name: Rebuild wiki container
   command:
-    cmd: docker compose build --no-cache && docker compose up -d
+    cmd: docker compose build --no-cache && docker compose up -d && docker builder prune -f --keep-storage 3GB
     chdir: /opt/pickipedia-docker

--- a/pickipedia-vps/ansible/roles/docker-wiki/tasks/main.yml
+++ b/pickipedia-vps/ansible/roles/docker-wiki/tasks/main.yml
@@ -66,6 +66,12 @@
     cmd: docker compose build
     chdir: /opt/pickipedia-docker
 
+# Cap BuildKit cache so repeated deploys don't accumulate unbounded.
+# -f prunes dangling cache only — active layers stay reusable;
+# --keep-storage caps total at 3GB.
+- name: Cap Docker BuildKit cache at 3GB
+  command: docker builder prune -f --keep-storage 3GB
+
 # Now the quick switchover — stop nginx, start container
 - name: Stop and disable nginx (replaced by Docker Apache)
   systemd:


### PR DESCRIPTION
## Why

delivery-kid's BuildKit cache grew to 28 GB across 337 entries on 2026-05-30 and took the host to 100% disk, killing the next deploy at the **Install required packages** task with the unhelpful \`Failed to update apt cache: unknown reason\`.

Root cause: every \`--rebuild\` deploy runs \`docker compose build --no-cache\`, and \`--no-cache\` bypasses cache *use* but still **creates new BuildKit cache entries**. With no prune step in the playbook, those entries accumulate forever. The same pattern existed in hunter's base-image rebuild and pickipedia-vps's wiki build — both would have hit this eventually.

## What

A new \`docker builder prune -f --keep-storage 3GB\` task right after every build site:

| Location | Insertion point |
|---|---|
| \`delivery-kid/ansible/playbook.yml\` | After **Start services** |
| \`hunter/ansible/roles/build-image/tasks/main.yml\` | After **Verify image was built** |
| \`pickipedia-vps/ansible/roles/docker-wiki/tasks/main.yml\` | After **Build wiki Docker image** |
| \`pickipedia-vps/ansible/roles/docker-wiki/handlers/main.yml\` | Chained inline in **Rebuild wiki container** |

## Flag choices

- **\`-f\` (force, no \`-a\`)** — prunes dangling cache only. Active layers (i.e. cache entries reusable by the current image) stay so the next cached build is still fast.
- **\`--keep-storage 3GB\`** — hard ceiling on total cache, regardless of dangling status. Even if every entry were "active" by Docker's reckoning, this caps growth.
- **No \`when:\` gate** — runs on every deploy. When cache is already under 3GB the task is essentially a no-op.

## Test plan

- [ ] Deploy delivery-kid with \`--rebuild\` — confirm task runs and \`/var/lib/docker\` doesn't grow unbounded
- [ ] Deploy hunter — confirm build cache stays bounded across rebuilds
- [ ] Re-deploy pickipedia-vps — confirm the after-build prune runs
- [ ] Verify \`docker system df\` on each host after a clean deploy: build cache should be ≤ 3GB

## Followup (out of scope here)

The dedup check in \`pickipedia_client.py\` is dead code due to \`snapshot_at\` always changing — flagged in #87 review. Worth a separate small PR.