### PR TITLE
delivery-kid: fix Coconut auth — use Basic auth, not Bearer

### DIFF
--- a/delivery-kid/pinning-service/app/services/coconut.py
+++ b/delivery-kid/pinning-service/app/services/coconut.py
@@ -146,14 +146,14 @@ async def submit_to_coconut(
         "webhook": webhook_url,
     }
 
+    # Coconut V2 wants HTTP Basic Auth (API key as username, empty password),
+    # not Bearer. With Bearer we got back "HTTP Basic: Access denied." 401s.
     async with httpx.AsyncClient(timeout=30.0) as client:
         resp = await client.post(
             COCONUT_API_URL,
             json=job_config,
-            headers={
-                "Authorization": f"Bearer {api_key}",
-                "Content-Type": "application/json",
-            },
+            auth=(api_key, ""),
+            headers={"Content-Type": "application/json"},
         )
         resp.raise_for_status()
         return resp.json()


### PR DESCRIPTION
## TL;DR

Coconut V2 wants HTTP Basic Auth (API key as username, empty password). We were sending \`Authorization: Bearer <key>\`. Every preview transcode submission has been failing with 401 since the original port of the integration.

## Verified end-to-end

From the delivery-kid host:

\`\`\`bash
KEY=\$(docker exec pinning-service printenv COCONUT_API_KEY)

# Current (broken) — what our code does
curl -H "Authorization: Bearer \$KEY" https://api.coconut.co/v2/jobs
# → HTTP 401  body: "HTTP Basic: Access denied."

# Fixed — what this PR does
curl -u "\$KEY:" https://api.coconut.co/v2/jobs
# → HTTP 200  body: {\"total_jobs\":0,\"jobs\":[]}
\`\`\`

The body \`HTTP Basic: Access denied.\` is the giveaway — it's from Coconut's auth *layer* rejecting the auth *scheme*, not from their API saying the key is invalid. So a healthy, in-date key that matches the dashboard still 401s as long as we keep sending Bearer.

## The change

\`\`\`diff
- headers={
-     "Authorization": f"Bearer {api_key}",
-     "Content-Type": "application/json",
- },
+ auth=(api_key, ""),
+ headers={"Content-Type": "application/json"},
\`\`\`

httpx's \`auth=(user, password)\` tuple sets the \`Authorization: Basic …\` header automatically. The empty password is what Coconut's docs prescribe — they only use the key as the username.

## How this got missed

Pre-existing bug from \`03de4cd\` (\"Port Coconut.co cloud transcoding to delivery-kid Python service\"). Nothing recent broke it. Surfaced today when a real upload reached \`preview_status: failed\` and the diagnostics panel from #82 actually showed the underlying httpx error — \`Client error '401 Unauthorized' for url 'https://api.coconut.co/v2/jobs'\` — which is what flipped this from \"transcoding is mysteriously broken\" to \"specifically a 401.\"

The #82 diagnostics panel paid for itself within an hour of merging.

## Test plan

- [ ] Deploy delivery-kid (no \`--rebuild\` needed — Python code change, container recreate is enough)
- [ ] Retry a video upload (e.g. ReleaseDraft:1cdc44a0-4143-408b-bfbd-fe9c8a6a2f63 or fresh)
- [ ] Confirm \`preview_status\` advances past \`pending\` without 401
- [ ] If the snapshot path is healthy, ReleaseDraft:{id}/diagnostics should now exist as a side effect of preview_status: ready