### PR TITLE
delivery-kid: source pickipedia bot creds from BLUERAILROAD_BOT_* vault keys

### DIFF
--- a/delivery-kid/ansible/playbook.yml
+++ b/delivery-kid/ansible/playbook.yml
@@ -142,8 +142,14 @@
                 # already provisioned for the Blue Railroad import tool. When
                 # the password var is empty the client no-ops cleanly.
                 - PICKIPEDIA_URL={{ pickipedia_url | default('https://pickipedia.xyz') }}
-                - PICKIPEDIA_BOT_USER={{ pickipedia_bot_user | default('Magent@magent') }}
-                - PICKIPEDIA_BOT_PASSWORD={{ pickipedia_bot_password | default('') }}
+                # Source the bot creds from the vault keys that maybelle's
+                # audit script already uses (BLUERAILROAD_BOT_*). Same bot,
+                # same password — there's no separate "pickipedia bot" in
+                # vault and the previously-referenced pickipedia_bot_*
+                # vault keys silently fell through to '', leaving the
+                # pickipedia_client's snapshot path a permanent no-op.
+                - PICKIPEDIA_BOT_USER={{ BLUERAILROAD_BOT_USERNAME | default('Magent@magent') }}
+                - PICKIPEDIA_BOT_PASSWORD={{ BLUERAILROAD_BOT_PASSWORD | default('') }}
               volumes:
                 - /mnt/storage-box/staging:/staging
               ports:


### PR DESCRIPTION
## TL;DR

\`pickipedia_client.snapshot_diagnostics\` has been silently no-op'ing since #87 landed. The bot password env var has been empty in the delivery-kid container the whole time. One-line-each rename fixes it.

## How we got here

The diagnostics-panel-on-the-wiki PR (#82) is rendering live state from \`/draft-content\` happily — that's why everything *looked* like it was working. But the *bot snapshot* path was never able to write \`ReleaseDraft:{id}/diagnostics\` because:

\`\`\`
docker exec pinning-service printenv PICKIPEDIA_BOT_PASSWORD
# → (empty)
\`\`\`

And the snapshot code does the right thing when creds are missing:

\`\`\`python
def _get_site():
    user = os.environ.get(\"PICKIPEDIA_BOT_USER\", \"Magent@magent\")
    password = os.environ.get(\"PICKIPEDIA_BOT_PASSWORD\")
    if not password:
        return None   # ← silent
\`\`\`

No log line, no exception — just \`False\` returned from \`snapshot_diagnostics\` and the caller moves on. Functionally invisible until you go looking for a wiki page that never appeared.

## Root cause

\`delivery-kid/ansible/playbook.yml\` referenced vault keys named \`pickipedia_bot_user\` / \`pickipedia_bot_password\`. **Those keys do not exist in vault.yml.** The Jinja defaults of \`''\` kicked in and the env vars landed empty in the container.

The Magent@magent BotPassword *does* exist in the vault — under different names: \`BLUERAILROAD_BOT_USERNAME\` and \`BLUERAILROAD_BOT_PASSWORD\`, the same keys that \`maybelle/scripts/post-audit-to-wiki.py\` reads to write the \`Cryptograss:Delivery-kid-audits/{blockheight}\` pages successfully every audit run. Same bot, same credential, different name in vault.

## The change

Two lines:

\`\`\`diff
- - PICKIPEDIA_BOT_USER={{ pickipedia_bot_user | default('Magent@magent') }}
- - PICKIPEDIA_BOT_PASSWORD={{ pickipedia_bot_password | default('') }}
+ - PICKIPEDIA_BOT_USER={{ BLUERAILROAD_BOT_USERNAME | default('Magent@magent') }}
+ - PICKIPEDIA_BOT_PASSWORD={{ BLUERAILROAD_BOT_PASSWORD | default('') }}
\`\`\`

No vault edit needed. No new secrets generated. Just point the consumer at the keys that already work.

## Test plan

- [ ] Deploy delivery-kid (no \`--rebuild\` needed — env var only)
- [ ] Confirm env in container: \`docker exec pinning-service printenv | grep PICKIPEDIA_BOT\` should show a non-empty password (or at least a non-zero length value)
- [ ] Re-upload to ReleaseDraft:664c391a-... (the existing test draft), let preview transcoding complete to \`preview_status: ready\`
- [ ] Check that \`https://pickipedia.xyz/wiki/ReleaseDraft:664c391a-b0f1-4628-b3d7-d593fdab5157/diagnostics\` now returns 200 with JSON
- [ ] If 4xx from the wiki: \`docker logs pinning-service | grep pickipedia_client\` will show the actual wiki error (perms, abusefilter, etc.) — answers the lingering \"does the bot have ReleaseDraft: namespace create perms?\" question that's been hanging since #87

## Follow-up worth doing soon (not in this PR)

\`pickipedia_client.py\` should log a single line at module init or first \`_get_site()\` call when \`PICKIPEDIA_BOT_PASSWORD\` is empty, so the silent-no-op pattern is visible in logs rather than purely deductive. Filing as a separate issue rather than bundling here.