### PR TITLE
delivery-kid: log once when PICKIPEDIA_BOT_PASSWORD is missing

### DIFF
--- a/delivery-kid/pinning-service/app/services/pickipedia_client.py
+++ b/delivery-kid/pinning-service/app/services/pickipedia_client.py
@@ -32,6 +32,10 @@ logger = logging.getLogger(__name__)
 _site = None
 _site_lock = Lock()
 
+# Tracks whether we've already complained about missing creds, so the log
+# warns exactly once per process rather than on every snapshot attempt.
+_warned_missing_creds = False
+
 
 def _parse_host(url: str) -> tuple[str, str]:
     """Split a wiki URL into (host, scheme) for mwclient.Site."""
@@ -44,13 +48,24 @@ def _parse_host(url: str) -> tuple[str, str]:
 
 def _get_site():
     """Return a logged-in mwclient.Site, or None if creds aren't configured."""
-    global _site
+    global _site, _warned_missing_creds
     if _site is not None:
         return _site
 
     user = os.environ.get("PICKIPEDIA_BOT_USER", "Magent@magent")
     password = os.environ.get("PICKIPEDIA_BOT_PASSWORD")
     if not password:
+        # Warn once per process. Previously this branch was silent and the
+        # snapshot path would no-op without explanation — we found it the
+        # hard way after a deploy left PICKIPEDIA_BOT_PASSWORD empty in the
+        # container env. One log line makes the silent failure visible.
+        if not _warned_missing_creds:
+            logger.warning(
+                "pickipedia_client: PICKIPEDIA_BOT_PASSWORD is empty — wiki "
+                "snapshots will silently no-op. Set the env var (sourced "
+                "from vault) to enable diagnostics-page snapshots."
+            )
+            _warned_missing_creds = True
         return None
 
     url = os.environ.get("PICKIPEDIA_URL", "https://pickipedia.xyz")


### PR DESCRIPTION
## What

When \`pickipedia_client._get_site()\` is called with no bot password set, it returned \`None\` silently — no log line, no signal, no diagnostic. This is how the silent no-op since #87 went undetected for weeks.

Add a single \`logger.warning\` the first time we hit that branch, gated on a module-level \`_warned_missing_creds\` flag so we warn once per process rather than spamming logs on every snapshot attempt.

## Why now

The snapshot path went silent for weeks. We found the gap by deductive reasoning (\"the page doesn't exist, the hook should have fired, where would the snapshot have logged about that\") rather than by reading a single explicit log entry. Future deployments where someone forgets to wire the env var (or the vault key gets renamed like #91 just did) will now surface in \`docker logs pinning-service\` immediately.

## Behavior

- **Creds set**: zero behavior change — \`_site\` is cached after first login, the missing-creds branch never runs
- **Creds empty**: one log line per process at WARNING level when the first snapshot attempt is made. Subsequent calls in the same process are still silent (the flag stays set)
- **Process restart with empty creds**: warns again once. The deploy that fixed #91 will, after restart, no longer trigger this warning at all

## Follow-up that came out of this debugging session

The decision in #87 to reuse the \`Magent@magent\` BotPassword from blue-railroad-import was a tactical shortcut. Different subsystem, different runtime, different code path — should ideally be a different bot identity (\`DeliveryKid@delivery-kid\` or similar) for clear attribution in wiki edit history. Filing as a separate issue rather than bundling.