### PR TITLE
delivery-kid: finalize webhook updates draft state (status, final_cid)

### DIFF
--- a/delivery-kid/pinning-service/app/routes/coconut.py
+++ b/delivery-kid/pinning-service/app/routes/coconut.py
@@ -67,6 +67,67 @@ def _append_preview_log(staging_dir: Path, draft_id: str, message: str,
         logger.error("[%s] Failed to append preview log: %s", draft_id[:8], e)
 
 
+def _update_draft_finalize(staging_dir: Path, job: dict) -> None:
+    """Update a content draft's finalize state after Coconut webhook.
+
+    Mirrors ``_update_draft_preview`` but for the finalize-side job:
+    sets ``state.status = 'finalized'`` + ``state.final_cid``, appends to
+    ``finalize_log`` so the wiki diagnostics panel can render the
+    completion, and fires the wiki-snapshot hook on the terminal state.
+
+    Without this, finalize jobs would pin HLS to IPFS but never write
+    anything back to the draft — the wiki page would stay stuck on
+    'finalizing' forever and the Blue Railroad Imports bot would have no
+    'finalized' state to react to, so no Release page would ever appear.
+    """
+    draft_id = job["draftId"]
+    draft_json = staging_dir / "drafts" / draft_id / "draft.json"
+    if not draft_json.exists():
+        logger.warning("[%s] Finalize draft not found: %s", job["id"], draft_id)
+        return
+    try:
+        data = json.loads(draft_json.read_text())
+        log = data.get("finalize_log") or []
+        now = datetime.now(timezone.utc).isoformat()
+        if job["status"] == "complete" and job.get("hlsCid"):
+            cid = job["hlsCid"]
+            data["status"] = "finalized"
+            data["final_cid"] = cid
+            data["finalized_at"] = now
+            log.append({
+                "ts": now,
+                "stage": "complete",
+                "message": f"Finalize complete · HLS pinned ({cid[:12]}…)",
+                "progress": 100,
+            })
+            logger.info("[%s] Draft %s finalized: hls=%s",
+                        job["id"], draft_id[:8], cid)
+        else:
+            data["status"] = "finalize_failed"
+            err = job.get("error") or "Unknown error"
+            log.append({
+                "ts": now,
+                "stage": "error",
+                "message": f"Finalize transcode failed: {err}",
+                "error": err,
+            })
+            logger.warning("[%s] Draft %s finalize failed: %s",
+                           job["id"], draft_id[:8], err)
+        # Match the cap used by _append_finalize_log in routes/content.py.
+        data["finalize_log"] = log[-200:]
+        draft_json.write_text(json.dumps(data, indent=2, default=str))
+
+        # Snapshot the terminal finalize state to the wiki sub-page so it
+        # survives a delivery-kid storage rebuild.
+        try:
+            import asyncio as _asyncio
+            _asyncio.create_task(snapshot_diagnostics_for_dict_async(draft_id, data))
+        except RuntimeError:
+            logger.debug("[%s] No running loop; skipping diagnostics snapshot", job["id"])
+    except Exception as e:
+        logger.error("[%s] Failed to update draft finalize state: %s", job["id"], e)
+
+
 def _update_draft_preview(staging_dir: Path, job: dict) -> None:
     """Update a content draft's preview state after Coconut webhook."""
     draft_id = job["draftId"]
@@ -283,9 +344,14 @@ async def webhook_coconut(request: Request, settings: Settings = Depends(get_set
 
         save_job(staging_dir, job_id, job)
 
-        # If this is a preview job, update the draft state
-        if job.get("isPreview") and job.get("draftId"):
-            _update_draft_preview(staging_dir, job)
+        # Mirror the job result back into the draft so the wiki page can
+        # render it. Two-headed: preview-side updates preview_status /
+        # preview_cid; finalize-side updates status / final_cid.
+        if job.get("draftId"):
+            if job.get("isPreview"):
+                _update_draft_preview(staging_dir, job)
+            else:
+                _update_draft_finalize(staging_dir, job)
         return {"received": True}
 
     except Exception as e:

--- a/delivery-kid/pinning-service/app/routes/content.py
+++ b/delivery-kid/pinning-service/app/routes/content.py
@@ -686,6 +686,12 @@ async def finalize_sse_generator(
                     "id": job_id,
                     "coconutJobId": coconut_job_id,
                     "status": "processing",
+                    # draftId lets the Coconut webhook handler map back to
+                    # the right draft when the job completes — otherwise the
+                    # webhook pins HLS but never updates state.final_cid /
+                    # state.status, leaving the wiki page stuck on
+                    # "finalizing" forever (preview path already does this).
+                    "draftId": draft_id,
                     "keepOriginal": request.preserve_original,
                     "title": request.title,
                     "fileType": request.file_type,


### PR DESCRIPTION
## TL;DR

The Coconut webhook handler only updates draft state for **preview** jobs. For **finalize** jobs it pins HLS to IPFS, stores \`hlsCid\` in the *job* state, returns 200 — and never touches the draft. So the wiki page stays stuck on \"finalizing\", and the Blue Railroad Imports bot never sees a finalized draft, so no Release page is ever created.

Verified end-to-end against today's terrapin re-finalize (PR #94 deploy):

\`\`\`
17:07:24 - Coconut V2 job submitted → 201
17:09:49 - Webhook received: job.completed
17:09:49 - HLS pinned: QmVUqPwgpSAYy7UmpeCfG64UzpxLZq6UZyULkdZnujny5H
[silence — no Release page, no diagnostics-panel update]
\`\`\`

## What this PR does

**1.** \`content.py\` finalize path adds \`draftId\` to \`job_state\` (was missing — preview-path had it, finalize-path didn't, so even with the new webhook updater below, mapping job → draft wouldn't work).

**2.** \`coconut.py\` adds \`_update_draft_finalize\` (mirror of \`_update_draft_preview\` for finalize) and wires it in:

\`\`\`python
if job.get(\"draftId\"):
    if job.get(\"isPreview\"):
        _update_draft_preview(staging_dir, job)
    else:
        _update_draft_finalize(staging_dir, job)
\`\`\`

On \`job.completed\`: sets \`state.status = \"finalized\"\`, \`state.final_cid = hlsCid\`, appends to \`finalize_log\`, fires the wiki-snapshot hook (terminal-state trigger).
On \`job.failed\`: sets \`state.status = \"finalize_failed\"\`, logs the error.

## How this got missed

Pre-existing gap, exposed by #94. Pre-V2, the finalize fast path was happily reusing \`preview_cid\` as the Release CID, so the slow-Coconut-finalize path rarely ran in practice. With the fast path disabled (V2 preview is mp4-only, not finalize-grade HLS), every finalize now goes through the slow path and hits this gap.

## Test plan

- [ ] Deploy delivery-kid (no \`--rebuild\` — Python only)
- [ ] Re-finalize the terrapin draft (or any in-flight Coconut-submitted finalize job)
- [ ] Watch \`docker logs pinning-service | grep -E \"finalize|content:\"\` — should see \`Draft <id> finalized: hls=Qm...\`
- [ ] Wiki ReleaseDraft page diagnostics panel reflects \`finalized\` + \`final_cid\` within one poll cycle
- [ ] Blue Railroad Imports bot creates \`Release:<hls_cid>\` on its next cron run
- [ ] Visit the new Release page; CID should resolve to a directory with \`master.m3u8\` + variant playlists + segments (real video content this time)