### PR TITLE
delivery-kid: webhook writes finalized state to ReleaseDraft wiki YAML

### DIFF
--- a/delivery-kid/pinning-service/app/routes/coconut.py
+++ b/delivery-kid/pinning-service/app/routes/coconut.py
@@ -94,6 +94,23 @@ def _update_draft_finalize(staging_dir: Path, job: dict) -> None:
             data["status"] = "finalized"
             data["final_cid"] = cid
             data["finalized_at"] = now
+            # Narrate each webhook-side step we actually did so the wiki
+            # diagnostics panel doesn't have a 2-minute gap between
+            # "transcoding-submitted" and "complete". The webhook handler
+            # itself only writes to draft.json once, so the multiple
+            # entries below are persisted in one save (we don't have a
+            # streaming mechanism back to the user's browser; the panel
+            # picks them all up on its next poll).
+            log.append({
+                "ts": now,
+                "stage": "webhook",
+                "message": "Coconut callback received — HLS ready",
+            })
+            log.append({
+                "ts": now,
+                "stage": "pin",
+                "message": f"HLS pinned to IPFS as {cid}",
+            })
             log.append({
                 "ts": now,
                 "stage": "complete",
@@ -124,6 +141,28 @@ def _update_draft_finalize(staging_dir: Path, job: dict) -> None:
             _asyncio.create_task(snapshot_diagnostics_for_dict_async(draft_id, data))
         except RuntimeError:
             logger.debug("[%s] No running loop; skipping diagnostics snapshot", job["id"])
+
+        # Update the ReleaseDraft:{id} wiki page YAML so the Blue Railroad
+        # Imports bot's find_cid_from_history picks up the new final_cid
+        # on its next cron run and creates the Release:{cid} page.
+        # Pre-V2 this edit was done by the browser-side JS when the SSE
+        # delivered a 'complete' event; the slow Coconut path closes the
+        # SSE long before completion, so we write it here instead.
+        if data.get("status") == "finalized" and data.get("final_cid"):
+            try:
+                import asyncio as _asyncio
+                from ..services.pickipedia_client import (
+                    write_finalized_to_releasedraft_async,
+                )
+                _asyncio.create_task(write_finalized_to_releasedraft_async(
+                    draft_id, data["final_cid"], data["finalized_at"],
+                ))
+            except RuntimeError:
+                logger.debug("[%s] No running loop; skipping ReleaseDraft YAML update",
+                             job["id"])
+            except Exception as e:
+                logger.warning("[%s] Failed to schedule ReleaseDraft YAML update: %s",
+                               job["id"], e)
     except Exception as e:
         logger.error("[%s] Failed to update draft finalize state: %s", job["id"], e)
 

--- a/delivery-kid/pinning-service/app/services/pickipedia_client.py
+++ b/delivery-kid/pinning-service/app/services/pickipedia_client.py
@@ -159,3 +159,89 @@ def snapshot_diagnostics_for_dict_async(draft_id: str, draft_data: dict):
         "preview_log": draft_data.get("preview_log") or [],
     }
     return asyncio.to_thread(snapshot_diagnostics, draft_id, payload)
+
+
+def write_finalized_to_releasedraft(
+    draft_id: str,
+    final_cid: str,
+    finalized_at: str,
+) -> bool:
+    """Edit the ``ReleaseDraft:{draft_id}`` wiki page YAML to mark it finalized.
+
+    Pre-V2-Coconut-migration, the browser-side JS handled this edit when
+    the finalize SSE delivered a ``complete`` event. For the slow Coconut
+    path that event never fires (the SSE closes after submission and the
+    user's browser doesn't see the eventual completion), so we write from
+    the webhook side instead.
+
+    The edit:
+      - Loads the current YAML
+      - Sets ``status: finalized``, ``final_cid: <cid>``, ``finalized_at: <iso>``
+      - Saves with summary ``Finalized: pinned to IPFS as <cid>``
+
+    The summary line is what the Blue Railroad Imports bot's
+    ``find_cid_from_history`` greps for to trigger Release page creation
+    on its next cron run.
+
+    Returns True if the edit succeeded, False if creds are missing or the
+    write failed. Never raises.
+    """
+    site = _get_site()
+    if site is None:
+        return False
+
+    try:
+        import yaml as _yaml
+    except ImportError:
+        logger.error("pickipedia_client: PyYAML not installed; cannot edit ReleaseDraft YAML")
+        return False
+
+    title = f"ReleaseDraft:{draft_id}"
+    try:
+        page = site.pages[title]
+        if not page.exists:
+            logger.warning("pickipedia_client: %s does not exist; cannot mark finalized", title)
+            return False
+
+        existing_text = page.text()
+        try:
+            data = _yaml.safe_load(existing_text) or {}
+        except _yaml.YAMLError as e:
+            logger.error("pickipedia_client: failed to parse %s YAML: %s", title, e)
+            return False
+
+        if not isinstance(data, dict):
+            logger.error("pickipedia_client: %s YAML is not a mapping; refusing to edit", title)
+            return False
+
+        data["status"] = "finalized"
+        data["final_cid"] = final_cid
+        data["finalized_at"] = finalized_at
+
+        new_text = _yaml.safe_dump(data, default_flow_style=False, sort_keys=False)
+        summary = f"Finalized: pinned to IPFS as {final_cid}"
+
+        if new_text.strip() == existing_text.strip():
+            return True
+
+        page.save(new_text, summary=summary)
+        logger.info("pickipedia_client: marked %s finalized (final_cid=%s)", title, final_cid)
+        return True
+    except Exception as e:
+        logger.error("pickipedia_client: failed to mark %s finalized: %s", title, e)
+        return False
+
+
+async def write_finalized_to_releasedraft_async(
+    draft_id: str,
+    final_cid: str,
+    finalized_at: str,
+):
+    """Async wrapper for ``write_finalized_to_releasedraft``.
+
+    Runs the sync mwclient calls in a thread so the FastAPI event loop
+    isn't blocked while the wiki round-trip happens.
+    """
+    return await asyncio.to_thread(
+        write_finalized_to_releasedraft, draft_id, final_cid, finalized_at,
+    )

--- a/delivery-kid/pinning-service/requirements.txt
+++ b/delivery-kid/pinning-service/requirements.txt
@@ -24,3 +24,7 @@ libtorrent>=2.0.0
 # MediaWiki client — used by pickipedia_client to snapshot draft
 # diagnostics to ReleaseDraft:{id}/diagnostics on terminal state.
 mwclient>=0.10.1
+
+# YAML parser — used by pickipedia_client to read/update the
+# ReleaseDraft:{id} wiki page YAML when finalize completes.
+PyYAML>=6.0


### PR DESCRIPTION
## Why

#95 closed half the gap — \`_update_draft_finalize\` now writes \`status=finalized\` + \`final_cid\` into delivery-kid's \`draft.json\` when the Coconut webhook arrives. But the **wiki** \`ReleaseDraft:{id}\` page YAML stays on the pre-finalize state because the historical "write the YAML edit" step was done by browser-side JS responding to an SSE \`complete\` event that the slow Coconut path never sends.

The Blue Railroad Imports bot's \`find_cid_from_history\` greps wiki edit summaries for *"Finalized: pinned to IPFS as <cid>"* to know which drafts to promote. With no such edit ever being made for V2-Coconut finalizes, no Release page ever appears, even though the HLS has been pinned end-to-end.

## What

Three connected changes:

**1. New \`pickipedia_client.write_finalized_to_releasedraft\`** — loads the current ReleaseDraft YAML, sets the three finalized-state fields (\`status\`, \`final_cid\`, \`finalized_at\`), saves with the bot-trigger summary. Preserves all user-supplied YAML fields by parse+update+dump rather than rewriting.

**2. \`_update_draft_finalize\` fires the wiki write** as an asyncio task right after the existing draft.json update and diagnostics snapshot. Same fire-and-forget pattern as the snapshot — wiki blips don't mask the underlying finalize outcome.

**3. Stage-by-stage \`finalize_log\` entries** so the wiki diagnostics panel narrates the webhook-side work instead of jumping straight from "transcoding-submitted" to "complete". All entries land in a single \`draft.json\` save (we don't have a stream back to the browser; the panel picks them up on its next poll).

Also: PyYAML added to requirements.txt — not used elsewhere in pinning-service, so wasn't guaranteed installed.

## Test plan

- [ ] Deploy delivery-kid with **\`--rebuild\`** (new PyYAML dep needs to be baked into the image)
- [ ] Re-finalize the terrapin draft
- [ ] Watch \`docker logs pinning-service\`: expect \`pickipedia_client: marked ReleaseDraft:{id} finalized\` after the Coconut webhook
- [ ] Wiki page revision history should show a "Finalized: pinned to IPFS as Qm..." edit by Magent@magent
- [ ] On the next Blue Railroad Imports cron run, \`Release:{hls_cid}\` appears
- [ ] New Release page resolves to a directory with \`master.m3u8\` + variant playlists + segments — real playable video, not a 421-byte \`metadata.json\` again

## Known followups (not in this PR)

- Coconut V2 quality variants (\`mp4:480p\`, \`mp4:720p\` style) — current finalize uses Coconut V2 defaults
- Trim (V2 syntax to be discovered)
- The modal UI on the wiki page still flashes through stages because it's SSE-driven and the SSE closes early. Real fix would be longer-lived SSE that monitors the webhook. The diagnostics panel (poll-based) does narrate progress correctly after this PR; the modal is the same UX gap as before.