### PR TITLE
delivery-kid: fetch draft content from a yt-dlp-compatible URL

### DIFF
--- a/delivery-kid/pinning-service/app/config.py
+++ b/delivery-kid/pinning-service/app/config.py
@@ -37,6 +37,11 @@ class Settings(BaseSettings):
     max_file_size_mb: int = 50000  # 50GB - effectively no limit for albums
     max_files_per_upload: int = 50
 
+    # Wall-clock ceiling for a /draft-content/from-url yt-dlp fetch. Generous
+    # because a long set filmed at 4K over a slow origin is a legitimate case;
+    # it exists to stop a wedged fetch holding staging space forever.
+    url_fetch_timeout_seconds: int = 3600
+
     # Draft settings
     # draft_ttl_hours removed — drafts persist until explicitly finalized or deleted
     max_staging_size_gb: int = 10  # Maximum total size of staging directory

--- a/delivery-kid/pinning-service/app/models/content.py
+++ b/delivery-kid/pinning-service/app/models/content.py
@@ -40,8 +40,9 @@ class ContentDraftState(BaseModel):
     # happened even after a refresh or a process crash.
     #   awaiting_upload — /init called, no bytes yet
     #   uploading       — file POST in flight
+    #   fetching        — /from-url accepted; yt-dlp is pulling bytes server-side
     #   uploaded        — files saved + analyzed; preview may be running
-    #   upload_failed   — file POST raised; see upload_log
+    #   upload_failed   — file POST or URL fetch raised; see upload_log
     #   finalizing      — finalize SSE in progress
     #   finalized       — pin successful
     #   finalize_failed — finalize SSE errored; draft dir kept for forensics
@@ -84,6 +85,11 @@ class ContentDraftResponse(BaseModel):
     preview_mp4_cid: Optional[str] = Field(default=None, description="IPFS CID of 480p preview MP4")
     preview_token: Optional[str] = Field(default=None, description="One-time token (returned only on init)")
     preview_log: list[dict] = Field(default_factory=list, description="Recent progress entries from Coconut webhook")
+
+
+class ContentFromUrlRequest(BaseModel):
+    """Request body for fetching draft content from a yt-dlp-compatible URL."""
+    url: str = Field(description="Page or media URL for yt-dlp to fetch (http/https only)")
 
 
 class ContentFinalizeRequest(BaseModel):

--- a/delivery-kid/pinning-service/app/routes/content.py
+++ b/delivery-kid/pinning-service/app/routes/content.py
@@ -16,9 +16,10 @@ from sse_starlette.sse import EventSourceResponse
 from ..auth import require_auth, require_finalize_auth, has_finalize_token
 from ..config import get_settings, get_commit, Settings
 from ..models.content import (
-    ContentFile, ContentDraftState, ContentDraftResponse, ContentFinalizeRequest
+    ContentFile, ContentDraftState, ContentDraftResponse, ContentFinalizeRequest,
+    ContentFromUrlRequest
 )
-from ..services import analyze, ipfs, transcode
+from ..services import analyze, ipfs, transcode, url_fetch
 from ..services.coconut import submit_to_coconut, save_job, load_job
 from ..services.fsutil import safe_rmtree
 from ..services.pickipedia_client import snapshot_diagnostics_for_state_async
@@ -162,6 +163,79 @@ def _fire_diagnostics_snapshot(state: ContentDraftState) -> None:
     except RuntimeError:
         logger.debug("[content:%s] No running loop; skipping diagnostics snapshot",
                      state.draft_id[:8])
+
+
+class NoUsableMediaError(Exception):
+    """Nothing in the upload directory survived analysis."""
+
+
+async def _analyze_and_mark_uploaded(
+    draft_id: str,
+    draft_dir: Path,
+    upload_dir: Path,
+    state: ContentDraftState,
+    settings: Settings,
+) -> list[ContentFile]:
+    """Analyse everything in upload_dir, record it on state, start any preview.
+
+    Shared by the multipart upload handler and the URL-fetch worker — bytes
+    arrive by two routes but everything after they land is identical, and
+    keeping one copy of it is the only way the two stay in step.
+
+    Persists state before returning. Caller owns the HTTP (or background)
+    error surface.
+
+    Raises:
+        NoUsableMediaError: nothing analysed successfully.
+    """
+    analyses = await analyze.analyze_media_directory(upload_dir)
+
+    draft_files = []
+    for a in analyses:
+        if a.success:
+            draft_files.append(ContentFile(
+                original_filename=a.original_filename,
+                detected_title=a.detected_title,
+                media_type=a.media_type,
+                format=a.format,
+                duration_seconds=a.duration_seconds,
+                sample_rate=a.sample_rate,
+                bit_depth=a.bit_depth,
+                channels=a.channels,
+                width=a.width,
+                height=a.height,
+                video_codec=a.video_codec,
+                audio_codec=a.audio_codec,
+                size_bytes=a.size_bytes,
+                creation_time=a.creation_time,
+            ))
+        else:
+            _append_upload_log(state, "analyze-error",
+                               f"ffprobe failed on {a.original_filename}",
+                               error=a.error or "unknown")
+
+    if not draft_files:
+        raise NoUsableMediaError("No valid media files found in upload")
+
+    # Determine if this is a single-video upload that should get a preview
+    video_files = [f for f in draft_files if f.media_type == "video"]
+    should_preview = len(draft_files) == 1 and len(video_files) == 1 and settings.coconut_api_key
+
+    state.files = draft_files
+    state.status = "uploaded"
+    state.preview_status = "pending" if should_preview else "none"
+    _append_upload_log(state, "analyzed",
+                       f"Analyzed {len(draft_files)} file(s); "
+                       + ("preview pending." if should_preview else "no preview."))
+    save_draft_state(draft_dir, state)
+
+    # Kick off background preview transcoding for video uploads
+    if should_preview:
+        asyncio.create_task(
+            _submit_preview_transcode(draft_id, state, settings)
+        )
+
+    return draft_files
 
 
 @router.post("/init", response_model=ContentDraftResponse)
@@ -324,54 +398,9 @@ async def create_content_draft(
                                f"Saved {file.filename} ({file_path.stat().st_size} bytes)")
         save_draft_state(draft_dir, state)
 
-        # Analyze all media files
-        analyses = await analyze.analyze_media_directory(upload_dir)
-
-        # Convert to ContentFile models
-        draft_files = []
-        for a in analyses:
-            if a.success:
-                draft_files.append(ContentFile(
-                    original_filename=a.original_filename,
-                    detected_title=a.detected_title,
-                    media_type=a.media_type,
-                    format=a.format,
-                    duration_seconds=a.duration_seconds,
-                    sample_rate=a.sample_rate,
-                    bit_depth=a.bit_depth,
-                    channels=a.channels,
-                    width=a.width,
-                    height=a.height,
-                    video_codec=a.video_codec,
-                    audio_codec=a.audio_codec,
-                    size_bytes=a.size_bytes,
-                    creation_time=a.creation_time,
-                ))
-            else:
-                _append_upload_log(state, "analyze-error",
-                                   f"ffprobe failed on {a.original_filename}",
-                                   error=a.error or "unknown")
-
-        if not draft_files:
-            raise fail(400, "No valid media files found in upload")
-
-        # Determine if this is a single-video upload that should get a preview
-        video_files = [f for f in draft_files if f.media_type == "video"]
-        should_preview = len(draft_files) == 1 and len(video_files) == 1 and settings.coconut_api_key
-
-        state.files = draft_files
-        state.status = "uploaded"
-        state.preview_status = "pending" if should_preview else "none"
-        _append_upload_log(state, "analyzed",
-                           f"Analyzed {len(draft_files)} file(s); "
-                           + ("preview pending." if should_preview else "no preview."))
-        save_draft_state(draft_dir, state)
-
-        # Kick off background preview transcoding for video uploads
-        if should_preview:
-            asyncio.create_task(
-                _submit_preview_transcode(draft_id, state, settings)
-            )
+        draft_files = await _analyze_and_mark_uploaded(
+            draft_id, draft_dir, upload_dir, state, settings
+        )
 
         return ContentDraftResponse(
             draft_id=draft_id,
@@ -384,10 +413,171 @@ async def create_content_draft(
 
     except HTTPException:
         raise
+    except NoUsableMediaError as e:
+        raise fail(400, str(e))
     except Exception as e:
         # Persistent record: keep draft_dir, log the failure, and surface it.
         logger.exception("[content:%s] Upload failed", draft_id[:8])
         raise fail(500, f"Upload error: {e}")
+
+
+async def _fetch_url_into_draft(
+    draft_id: str,
+    url: str,
+    settings: Settings,
+) -> None:
+    """Background worker: pull ``url`` into the draft, then analyse it.
+
+    Runs detached from the request that started it, so every outcome has to
+    land in draft.json — that file (mirrored to the ReleaseDraft page) is the
+    only thing the client can see once the 202 has gone out.
+    """
+    staging_dir = Path(settings.staging_dir)
+    draft_dir = get_draft_dir(staging_dir, draft_id)
+    upload_dir = draft_dir / "upload"
+    fetch_dir = draft_dir / "fetch"
+
+    state = load_draft_state(draft_dir)
+    if state is None:
+        logger.error("[content:%s] Draft vanished before fetch started", draft_id[:8])
+        return
+
+    def persist_failure(message: str) -> None:
+        state.status = "upload_failed"
+        _append_upload_log(state, "error", message, error=message)
+        try:
+            save_draft_state(draft_dir, state)
+        except Exception:
+            logger.exception("[content:%s] Could not persist fetch failure", draft_id[:8])
+        _fire_diagnostics_snapshot(state)
+
+    try:
+        # Both dirs start empty: a retry into an existing draft shouldn't
+        # leave last attempt's partial file to be picked up as the media.
+        for d in (upload_dir, fetch_dir):
+            if d.exists():
+                safe_rmtree(d)
+        upload_dir.mkdir(parents=True, exist_ok=True)
+        fetch_dir.mkdir(parents=True, exist_ok=True)
+
+        last_logged_decile = -1
+
+        async def on_progress(line: str, pct: float | None) -> None:
+            nonlocal last_logged_decile
+            if pct is None:
+                return
+            decile = int(pct) // 10
+            if decile == last_logged_decile:
+                return
+            last_logged_decile = decile
+            _append_upload_log(state, "fetching", line)
+            try:
+                save_draft_state(draft_dir, state)
+            except Exception:
+                logger.warning("[content:%s] Could not persist fetch progress",
+                               draft_id[:8])
+
+        result = await url_fetch.fetch_url_to_dir(
+            url,
+            fetch_dir,
+            max_filesize_mb=settings.max_file_size_mb,
+            timeout_seconds=settings.url_fetch_timeout_seconds,
+            progress_callback=on_progress,
+        )
+
+        if not result.success or result.file_path is None:
+            persist_failure(result.error or "Fetch failed for an unknown reason")
+            return
+
+        # Only the media file moves into upload/ — that directory is what gets
+        # pinned, and the .info.json sidecar stays behind in fetch/ where it
+        # remains available for forensics without ending up on IPFS.
+        destination = upload_dir / result.file_path.name
+        shutil.move(str(result.file_path), str(destination))
+        _append_upload_log(
+            state, "received",
+            f"Fetched {destination.name} ({destination.stat().st_size} bytes) from {url}"
+        )
+
+        if result.info:
+            extracted = url_fetch.source_metadata(result.info)
+            # User-entered metadata always wins; these only fill gaps.
+            for key, value in extracted.items():
+                state.metadata.setdefault(key, value)
+        state.metadata.setdefault("source_url", url)
+
+        save_draft_state(draft_dir, state)
+
+        await _analyze_and_mark_uploaded(
+            draft_id, draft_dir, upload_dir, state, settings
+        )
+
+    except NoUsableMediaError as e:
+        persist_failure(str(e))
+    except Exception as e:
+        logger.exception("[content:%s] URL fetch failed", draft_id[:8])
+        persist_failure(f"Fetch error: {e}")
+
+
+@router.post("/from-url", response_model=ContentDraftResponse, status_code=202)
+async def create_content_draft_from_url(
+    body: ContentFromUrlRequest,
+    x_draft_id: str = Header(alias="X-Draft-Id"),
+    wallet_address: str = Depends(require_auth),
+    settings: Settings = Depends(get_settings)
+):
+    """
+    Fetch draft content from a yt-dlp-compatible URL instead of uploading it.
+
+    Server-side mirror of ``POST /draft-content``: delivery-kid pulls the bytes
+    rather than the browser pushing them. Returns 202 as soon as the fetch is
+    accepted — a long download would otherwise sit past the reverse proxy's
+    timeout — and the client watches ``GET /draft-content/{draft_id}`` for
+    ``status`` and ``upload_log`` until it reads ``uploaded`` or
+    ``upload_failed``.
+
+    ``X-Draft-Id`` is required (unlike the multipart endpoint, which tolerates
+    its absence): the draft and its ReleaseDraft page must already exist, or a
+    fetch that fails has nowhere to report itself.
+    """
+    staging_dir = Path(settings.staging_dir)
+
+    try:
+        uuid.UUID(x_draft_id)
+    except ValueError:
+        raise HTTPException(status_code=400, detail="X-Draft-Id must be a valid UUID")
+
+    draft_dir = get_draft_dir(staging_dir, x_draft_id)
+    state = load_draft_state(draft_dir)
+    if state is None:
+        raise HTTPException(
+            status_code=404,
+            detail="Content draft not found — call /draft-content/init first"
+        )
+    if state.uploaded_by.lower() != wallet_address.lower():
+        raise HTTPException(status_code=403, detail="You do not own this draft")
+
+    try:
+        url = url_fetch.validate_fetchable_url(body.url)
+    except url_fetch.UrlNotAllowed as e:
+        # Rejected before any state change — the draft stays as it was, so the
+        # user can correct the URL and post again.
+        raise HTTPException(status_code=400, detail=str(e))
+
+    state.status = "fetching"
+    _append_upload_log(state, "fetch-start", f"Fetching {url} with yt-dlp...")
+    save_draft_state(draft_dir, state)
+
+    asyncio.create_task(_fetch_url_into_draft(x_draft_id, url, settings))
+
+    return ContentDraftResponse(
+        draft_id=x_draft_id,
+        files=[],
+        commit=get_commit(),
+        status=state.status,
+        upload_log=state.upload_log,
+        preview_status=state.preview_status,
+    )
 
 
 @router.get("/{draft_id}", response_model=ContentDraftResponse)

--- a/delivery-kid/pinning-service/app/services/url_fetch.py
+++ b/delivery-kid/pinning-service/app/services/url_fetch.py
@@ -1,0 +1,304 @@
+"""Fetch media from a yt-dlp-compatible URL into a draft's staging directory.
+
+Server-side counterpart to the browser's multipart upload: instead of the
+client pushing bytes, delivery-kid pulls them. Everything downstream
+(analysis, preview transcode, finalize, pin) is identical either way.
+"""
+
+import asyncio
+import ipaddress
+import json
+import logging
+import re
+import socket
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Awaitable, Callable, Optional
+from urllib.parse import urlparse
+
+from . import analyze
+
+logger = logging.getLogger(__name__)
+
+
+# yt-dlp happily accepts file://, ytsearch:, and other non-network schemes.
+# Only these two ever make sense from an untrusted caller.
+ALLOWED_SCHEMES = {"http", "https"}
+
+# Percentage lines look like:
+#   [download]  12.3% of ~100.00MiB at 1.00MiB/s ETA 00:30
+_PROGRESS_RE = re.compile(r"\[download\]\s+([\d.]+)%")
+
+
+class UrlNotAllowed(ValueError):
+    """The supplied URL failed the pre-flight safety check."""
+
+
+@dataclass
+class FetchResult:
+    success: bool
+    file_path: Optional[Path] = None
+    info: Optional[dict] = None
+    error: Optional[str] = None
+
+
+def _is_public_address(ip: ipaddress.IPv4Address | ipaddress.IPv6Address) -> bool:
+    """True only for addresses that route on the public internet."""
+    # IPv4-mapped IPv6 (::ffff:10.0.0.2) must be judged on the embedded v4 address,
+    # which the IPv6 is_private check alone does not catch.
+    if isinstance(ip, ipaddress.IPv6Address) and ip.ipv4_mapped is not None:
+        ip = ip.ipv4_mapped
+    return not (
+        ip.is_private
+        or ip.is_loopback
+        or ip.is_link_local
+        or ip.is_multicast
+        or ip.is_reserved
+        or ip.is_unspecified
+    )
+
+
+def validate_fetchable_url(url: str) -> str:
+    """Reject non-http(s) schemes and hosts that resolve into private space.
+
+    delivery-kid sits on a private network alongside IPFS and the storage box,
+    so an unchecked server-side fetch is an SSRF primitive. This blocks the
+    direct cases.
+
+    Known limits, accepted deliberately rather than papered over:
+
+    - **DNS rebinding.** We resolve here; yt-dlp resolves again when it
+      fetches. A hostile resolver can answer differently the second time.
+    - **Redirects.** yt-dlp follows them itself, and a public URL can redirect
+      to an internal one.
+
+    Closing both properly means pinning the resolved address for the actual
+    transfer, which yt-dlp gives us no hook for. The durable fix is egress
+    filtering on the delivery-kid host. Callers are authenticated wiki users,
+    and fetched bytes are only ever surfaced back to the draft owner, so the
+    residual exposure is bounded.
+
+    Returns the URL unchanged when it passes.
+
+    Raises:
+        UrlNotAllowed: scheme is not http/https, host is missing or
+            unresolvable, or any resolved address is non-public.
+    """
+    parsed = urlparse(url.strip())
+
+    if parsed.scheme.lower() not in ALLOWED_SCHEMES:
+        raise UrlNotAllowed(
+            f"Only http and https URLs are accepted (got '{parsed.scheme or 'no scheme'}')"
+        )
+
+    host = parsed.hostname
+    if not host:
+        raise UrlNotAllowed("URL has no host")
+
+    try:
+        infos = socket.getaddrinfo(host, None)
+    except socket.gaierror as e:
+        raise UrlNotAllowed(f"Could not resolve host '{host}': {e}") from e
+
+    if not infos:
+        raise UrlNotAllowed(f"Could not resolve host '{host}'")
+
+    for info in infos:
+        addr = info[4][0]
+        try:
+            ip = ipaddress.ip_address(addr)
+        except ValueError:
+            raise UrlNotAllowed(f"Host '{host}' resolved to an unparseable address")
+        if not _is_public_address(ip):
+            raise UrlNotAllowed(
+                f"Host '{host}' resolves to non-public address {addr}"
+            )
+
+    return url.strip()
+
+
+def _build_command(url: str, dest_dir: Path, max_filesize_mb: int) -> list[str]:
+    """Assemble the yt-dlp argv.
+
+    ``--no-playlist`` matters: the dropzone this mirrors takes one file, and a
+    URL that happens to carry a list parameter would otherwise pull the whole
+    playlist into the draft.
+    """
+    return [
+        "yt-dlp",
+        # Never read a config file — it could inject arbitrary options.
+        # (.netrc is already opt-in via --netrc, which we simply don't pass.)
+        "--ignore-config",
+        "--no-config-locations",
+        "--no-playlist",
+        "--no-continue",
+        # ASCII-only names; the analyzer and IPFS layers both prefer them.
+        "--restrict-filenames",
+        # One progress line per update rather than carriage-return repaints.
+        "--newline",
+        "--no-color",
+        "--max-filesize", f"{max_filesize_mb}M",
+        "--merge-output-format", "mp4/mkv/webm",
+        "-f", "bv*+ba/b",
+        # Sidecar metadata — feeds the title/description pre-fill on the form.
+        "--write-info-json",
+        "--paths", f"home:{dest_dir}",
+        "-o", "%(title).120s-%(id)s.%(ext)s",
+        "--",
+        url,
+    ]
+
+
+def _pick_media_file(dest_dir: Path) -> Optional[Path]:
+    """Largest file in dest_dir with an extension the analyzer accepts."""
+    allowed = (
+        analyze.AUDIO_EXTENSIONS | analyze.VIDEO_EXTENSIONS | analyze.IMAGE_EXTENSIONS
+    )
+    candidates = [
+        p for p in dest_dir.iterdir()
+        if p.is_file() and p.suffix.lower() in allowed
+    ]
+    if not candidates:
+        return None
+    return max(candidates, key=lambda p: p.stat().st_size)
+
+
+def _read_info_json(dest_dir: Path) -> Optional[dict]:
+    """Parse the first .info.json yt-dlp wrote, if any."""
+    for p in sorted(dest_dir.glob("*.info.json")):
+        try:
+            with open(p) as f:
+                return json.load(f)
+        except (OSError, json.JSONDecodeError):
+            logger.warning("Could not parse info json at %s", p)
+    return None
+
+
+def source_metadata(info: dict) -> dict:
+    """Project a yt-dlp info dict onto the handful of fields the form pre-fills.
+
+    Namespaced under ``source_*`` so it never collides with — or silently
+    overwrites — metadata the user typed in themselves.
+    """
+    upload_date = info.get("upload_date")  # YYYYMMDD
+    if upload_date and len(upload_date) == 8 and upload_date.isdigit():
+        upload_date = f"{upload_date[:4]}-{upload_date[4:6]}-{upload_date[6:]}"
+
+    fields = {
+        "source_url": info.get("webpage_url") or info.get("original_url"),
+        "source_title": info.get("title"),
+        "source_description": info.get("description"),
+        "source_uploader": info.get("uploader") or info.get("channel"),
+        "source_upload_date": upload_date,
+        "source_duration_seconds": info.get("duration"),
+        "source_extractor": info.get("extractor_key") or info.get("extractor"),
+    }
+    return {k: v for k, v in fields.items() if v not in (None, "")}
+
+
+async def fetch_url_to_dir(
+    url: str,
+    dest_dir: Path,
+    *,
+    max_filesize_mb: int,
+    timeout_seconds: int,
+    progress_callback: Optional[Callable[[str, Optional[float]], Awaitable[None]]] = None,
+) -> FetchResult:
+    """Run yt-dlp against ``url``, depositing media into ``dest_dir``.
+
+    Args:
+        url: Already passed through validate_fetchable_url.
+        dest_dir: Created if absent. Receives the media file plus its
+            ``.info.json`` sidecar.
+        max_filesize_mb: Passed to ``--max-filesize``; yt-dlp skips anything
+            larger rather than downloading and then failing.
+        timeout_seconds: Wall-clock ceiling for the whole fetch.
+        progress_callback: Awaited with (message, percent) as output arrives.
+            Percent is None for non-progress lines.
+
+    Returns:
+        FetchResult. ``success`` False carries a human-readable ``error``;
+        this never raises for an ordinary download failure.
+    """
+    dest_dir.mkdir(parents=True, exist_ok=True)
+    cmd = _build_command(url, dest_dir, max_filesize_mb)
+
+    try:
+        proc = await asyncio.create_subprocess_exec(
+            *cmd,
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.STDOUT,
+        )
+    except FileNotFoundError:
+        return FetchResult(success=False, error="yt-dlp is not installed on this server")
+    except Exception as e:
+        return FetchResult(success=False, error=f"Could not start yt-dlp: {e}")
+
+    loop = asyncio.get_running_loop()
+    deadline = loop.time() + timeout_seconds
+    tail: list[str] = []
+    last_reported: Optional[int] = None
+
+    try:
+        while True:
+            remaining = deadline - loop.time()
+            if remaining <= 0:
+                raise asyncio.TimeoutError
+
+            line_bytes = await asyncio.wait_for(proc.stdout.readline(), remaining)
+            if not line_bytes:
+                break
+
+            line = line_bytes.decode("utf-8", errors="replace").rstrip()
+            if not line:
+                continue
+
+            # Keep a bounded tail so a failure message survives to the caller
+            # without dragging megabytes of progress spam into draft.json.
+            tail.append(line)
+            if len(tail) > 20:
+                tail.pop(0)
+
+            if progress_callback is None:
+                continue
+
+            match = _PROGRESS_RE.search(line)
+            if match:
+                pct = float(match.group(1))
+                # One callback per whole percent; yt-dlp emits far more.
+                bucket = int(pct)
+                if last_reported is not None and bucket == last_reported:
+                    continue
+                last_reported = bucket
+                await progress_callback(line, pct)
+            else:
+                await progress_callback(line, None)
+
+        await asyncio.wait_for(proc.wait(), max(deadline - loop.time(), 1))
+
+    except asyncio.TimeoutError:
+        proc.kill()
+        await proc.wait()
+        return FetchResult(
+            success=False,
+            error=f"Fetch exceeded the {timeout_seconds}s limit and was stopped",
+        )
+    except Exception as e:
+        proc.kill()
+        await proc.wait()
+        logger.exception("yt-dlp fetch failed for %s", url)
+        return FetchResult(success=False, error=f"Fetch error: {e}")
+
+    if proc.returncode != 0:
+        detail = " | ".join(tail[-5:]) or f"exit code {proc.returncode}"
+        return FetchResult(success=False, error=f"yt-dlp failed: {detail}")
+
+    media = _pick_media_file(dest_dir)
+    if media is None:
+        detail = " | ".join(tail[-5:]) or "no recognised media file was produced"
+        return FetchResult(
+            success=False,
+            error=f"Fetch produced no usable media file: {detail}",
+        )
+
+    return FetchResult(success=True, file_path=media, info=_read_info_json(dest_dir))

--- a/delivery-kid/pinning-service/requirements.txt
+++ b/delivery-kid/pinning-service/requirements.txt
@@ -18,6 +18,11 @@ pydantic-settings>=2.1.0
 # Audio processing
 pydub>=0.25.1
 
+# Media fetching for /draft-content/from-url. Unpinned deliberately: sites
+# break yt-dlp constantly and upstream ships fixes weekly, so an image rebuild
+# should pick up the newest extractors.
+yt-dlp>=2025.1.1
+
 # BitTorrent seeding
 libtorrent>=2.0.0
 

--- a/delivery-kid/pinning-service/tests/test_url_fetch.py
+++ b/delivery-kid/pinning-service/tests/test_url_fetch.py
@@ -1,0 +1,163 @@
+"""Tests for app.services.url_fetch — URL safety, metadata projection, file pick."""
+
+import socket
+from unittest.mock import patch
+
+import pytest
+
+from app.services.url_fetch import (
+    UrlNotAllowed,
+    _build_command,
+    _pick_media_file,
+    source_metadata,
+    validate_fetchable_url,
+)
+
+
+def _resolves_to(*addresses: str):
+    """Patch getaddrinfo so URL validation never depends on live DNS."""
+    infos = []
+    for addr in addresses:
+        family = socket.AF_INET6 if ":" in addr else socket.AF_INET
+        infos.append((family, socket.SOCK_STREAM, 6, "", (addr, 0)))
+    return patch("socket.getaddrinfo", return_value=infos)
+
+
+class TestValidateFetchableUrl:
+    def test_accepts_public_https(self):
+        with _resolves_to("142.250.72.14"):
+            assert validate_fetchable_url("https://example.com/watch?v=abc") == \
+                "https://example.com/watch?v=abc"
+
+    def test_accepts_public_http(self):
+        with _resolves_to("142.250.72.14"):
+            assert validate_fetchable_url("http://example.com/v.mp4")
+
+    def test_strips_surrounding_whitespace(self):
+        with _resolves_to("142.250.72.14"):
+            assert validate_fetchable_url("  https://example.com/x  ") == \
+                "https://example.com/x"
+
+    @pytest.mark.parametrize("url", [
+        "file:///etc/passwd",
+        "ftp://example.com/x.mp4",
+        "ytsearch:bluegrass",
+        "/etc/passwd",
+    ])
+    def test_rejects_non_http_schemes(self, url):
+        with pytest.raises(UrlNotAllowed):
+            validate_fetchable_url(url)
+
+    def test_rejects_missing_host(self):
+        with pytest.raises(UrlNotAllowed, match="no host"):
+            validate_fetchable_url("http:///justapath")
+
+    @pytest.mark.parametrize("addr", [
+        "127.0.0.1",        # loopback
+        "10.0.0.2",         # private — maybelle
+        "192.168.1.10",     # private
+        "172.16.4.4",       # private
+        "169.254.169.254",  # link-local, the classic metadata endpoint
+        "0.0.0.0",          # unspecified
+        "::1",              # IPv6 loopback
+        "fe80::1",          # IPv6 link-local
+        "fc00::1",          # IPv6 unique-local
+    ])
+    def test_rejects_internal_addresses(self, addr):
+        with _resolves_to(addr):
+            with pytest.raises(UrlNotAllowed, match="non-public"):
+                validate_fetchable_url("https://sneaky.example.com/x")
+
+    def test_rejects_ipv4_mapped_ipv6(self):
+        # ::ffff:10.0.0.2 is not "private" as an IPv6Address; it has to be
+        # judged on the embedded v4 address or it slips straight through.
+        with _resolves_to("::ffff:10.0.0.2"):
+            with pytest.raises(UrlNotAllowed, match="non-public"):
+                validate_fetchable_url("https://sneaky.example.com/x")
+
+    def test_rejects_when_any_resolved_address_is_internal(self):
+        # A host answering with one public and one private address must not
+        # pass on the strength of the public one.
+        with _resolves_to("142.250.72.14", "127.0.0.1"):
+            with pytest.raises(UrlNotAllowed, match="non-public"):
+                validate_fetchable_url("https://split.example.com/x")
+
+    def test_rejects_unresolvable_host(self):
+        with patch("socket.getaddrinfo", side_effect=socket.gaierror("nope")):
+            with pytest.raises(UrlNotAllowed, match="Could not resolve"):
+                validate_fetchable_url("https://nx.example.com/x")
+
+
+class TestBuildCommand:
+    def test_disables_playlist_expansion(self, tmp_path):
+        # A URL carrying a list= parameter would otherwise drag the whole
+        # playlist into a draft meant to hold one video.
+        assert "--no-playlist" in _build_command("https://x/y", tmp_path, 100)
+
+    def test_ignores_user_config(self, tmp_path):
+        cmd = _build_command("https://x/y", tmp_path, 100)
+        assert "--ignore-config" in cmd
+        assert "--no-config-locations" in cmd
+
+    def test_passes_size_cap_and_url_last(self, tmp_path):
+        cmd = _build_command("https://x/y", tmp_path, 250)
+        assert cmd[cmd.index("--max-filesize") + 1] == "250M"
+        # `--` then the URL, so a URL starting with a dash can't become a flag.
+        assert cmd[-2:] == ["--", "https://x/y"]
+
+
+class TestPickMediaFile:
+    def test_returns_none_when_empty(self, tmp_path):
+        assert _pick_media_file(tmp_path) is None
+
+    def test_ignores_info_json_sidecar(self, tmp_path):
+        (tmp_path / "clip.info.json").write_text("{}")
+        assert _pick_media_file(tmp_path) is None
+
+    def test_picks_largest_media_file(self, tmp_path):
+        (tmp_path / "small.mp4").write_bytes(b"x" * 10)
+        (tmp_path / "big.mkv").write_bytes(b"x" * 500)
+        (tmp_path / "clip.info.json").write_text("{}")
+        assert _pick_media_file(tmp_path).name == "big.mkv"
+
+    def test_accepts_audio_only_fetch(self, tmp_path):
+        (tmp_path / "tune.m4a").write_bytes(b"x" * 10)
+        assert _pick_media_file(tmp_path).name == "tune.m4a"
+
+
+class TestSourceMetadata:
+    def test_namespaces_and_reformats_date(self):
+        out = source_metadata({
+            "webpage_url": "https://example.com/watch?v=abc",
+            "title": "Flatpicking at Station Inn",
+            "uploader": "Justin Holmes",
+            "upload_date": "20260614",
+            "duration": 212,
+            "extractor_key": "Youtube",
+        })
+        assert out["source_url"] == "https://example.com/watch?v=abc"
+        assert out["source_title"] == "Flatpicking at Station Inn"
+        assert out["source_uploader"] == "Justin Holmes"
+        assert out["source_upload_date"] == "2026-06-14"
+        assert out["source_duration_seconds"] == 212
+        assert out["source_extractor"] == "Youtube"
+        # Every key namespaced, so a merge can't clobber user-entered fields.
+        assert all(k.startswith("source_") for k in out)
+
+    def test_drops_empty_and_missing_fields(self):
+        out = source_metadata({"title": "", "description": None, "uploader": "RJ"})
+        assert "source_title" not in out
+        assert "source_description" not in out
+        assert out["source_uploader"] == "RJ"
+
+    def test_leaves_malformed_date_alone(self):
+        assert source_metadata({"upload_date": "June 2026"})["source_upload_date"] == \
+            "June 2026"
+
+    def test_falls_back_to_channel_and_original_url(self):
+        out = source_metadata({"channel": "Cryptograss", "original_url": "https://x/y"})
+        assert out["source_uploader"] == "Cryptograss"
+        assert out["source_url"] == "https://x/y"
+
+    def test_empty_info_yields_empty_dict(self):
+        assert source_metadata({}) == {}


### PR DESCRIPTION
Adds `POST /draft-content/from-url` — a server-side mirror of the existing multipart upload. delivery-kid pulls the bytes instead of the browser pushing them; everything downstream (analysis, preview transcode, finalize, pin) is untouched because bytes land in the same `upload/` dir either way.

This is the delivery-kid half. The `Special:DeliverVideo` side (URL field + JS branch) is a companion PR in `cryptograss/pickipedia`.

## Shape

- `POST /draft-content/from-url`, body `{url}`, header `X-Draft-Id` (required — the draft and its ReleaseDraft page must already exist, or a failed fetch has nowhere to report itself).
- Returns **202** rather than blocking. A long fetch would sit past Caddy's timeout. Client polls `GET /draft-content/{id}` for `status` + `upload_log` until it reads `uploaded` or `upload_failed`. New `fetching` status covers the window between.
- `_analyze_and_mark_uploaded()` extracted from `create_content_draft` so the upload and fetch paths share one copy of the analyse-and-preview step instead of drifting.
- yt-dlp's `.info.json` stays in `fetch/` and never enters `upload/`, so it can't end up pinned.
- `source_*` metadata (title, uploader, upload date, duration) merged with `setdefault` — user-entered values always win.

## Security

`validate_fetchable_url()` rejects non-http(s) schemes and any host resolving into private/loopback/link-local space, including IPv4-mapped IPv6. Without it this is an SSRF primitive on a box sharing a network with IPFS and the storage box.

It does **not** close DNS rebinding or redirect-to-internal — yt-dlp offers no hook to pin the resolved address for the actual transfer. Documented honestly in the docstring; the durable fix is egress filtering on the delivery-kid host. Callers are authenticated wiki users and fetched bytes only ever return to the draft owner, so residual exposure is bounded.

`--no-playlist` is load-bearing: a URL carrying a `list=` parameter would otherwise pull an entire playlist into one draft. `--ignore-config` / `--no-config-locations` stop a config file injecting options.

## Testing

- 32 new unit tests in `tests/test_url_fetch.py` (SSRF guard, argv construction, media-file pick, metadata projection). DNS is mocked, so they don't depend on the network.
- Full suite: **62 passed, 4 failed**. The 4 failures are in `test_coconut.py` and reproduce on unmodified `production` — pre-existing, not from this change.
- End-to-end against live URLs: Instagram ✅ (48MB, metadata extracted), direct MP4 ✅.

## Known gap — YouTube

YouTube currently fails from a datacenter IP with `Sign in to confirm you're not a bot`. That's independent of this change, but it matters for the use case, and it needs a cookie story we haven't designed. Instagram and generic media URLs work today.

https://claude.ai/code/session_015YGcYQ1UzPuNAxQhHTcCz6