### PR TITLE
maybelle: finish retiring pickipedia-enrich-torrents

### DIFF
--- a/maybelle/ansible/maybelle.yml
+++ b/maybelle/ansible/maybelle.yml
@@ -150,6 +150,7 @@
         - pickipedia-rsync-status.groovy
         - backup-pickipedia.groovy
         - backup-memory-lane.groovy
+        - pickipedia-enrich-torrents.groovy
       notify: Restart Jenkins container
 
     # Jenkins persists job runtime state (config.xml, builds/) in
@@ -167,6 +168,7 @@
         - pickipedia-rsync-status
         - backup-pickipedia
         - backup-memory-lane
+        - pickipedia-enrich-torrents
       notify: Restart Jenkins container
 
     - name: Check if log paths are directories (Docker creates dirs for missing mount sources)

--- a/maybelle/configs/jenkins.yml
+++ b/maybelle/configs/jenkins.yml
@@ -52,7 +52,6 @@ jobs:
   - file: /var/jenkins_home/jobs/pickipedia-uptime.groovy
   - file: /var/jenkins_home/jobs/pickipedia-import-bluerailroad.groovy
   - file: /var/jenkins_home/jobs/arthel-fetch-pinata-data.groovy
-  - file: /var/jenkins_home/jobs/pickipedia-enrich-torrents.groovy
 
 credentials:
   system:


### PR DESCRIPTION
`b1983ae` (2026-04-14) folded torrent and IPFS enrichment into `pickipedia-import-bluerailroad` and deleted the standalone job's `.groovy`. It missed the other two thirds of a retirement: the JCasC `jobs:` entry and the two ansible removal loops.

## Two consequences, both still live

**1. Jenkins will crash-loop on a fresh provision.** JCasC references `/var/jenkins_home/jobs/pickipedia-enrich-torrents.groovy`, which isn't in the repo. The comment directly above the copy task spells out what that means:

> Job .groovy files MUST be copied before the container starts. JCasC's `jobs:` list references each .groovy by absolute path; if any file is missing when Jenkins boots, JCasC throws NoSuchFileException and Jenkins enters a crash loop.

**2. The retired job is probably still running.** It hasn't crash-looped yet precisely *because* `copy` doesn't delete — the April-era `.groovy` is presumably still sitting in `jenkins_home`. Which means it's still being loaded, on its original schedule:

```groovy
cron('*/2 * * * *')  // Run every 2 minutes
```

Calling delivery-kid for torrent generation, probing the IPFS gateway, and writing to the wiki via the Blue Railroad bot — **every two minutes since April**, duplicating what the import job now does as a stage.

## The fix

- Remove the JCasC entry.
- Add `pickipedia-enrich-torrents.groovy` to the retired-`.groovy` loop, so it stops being loaded.
- Add `pickipedia-enrich-torrents` to the retired-runtime-directory loop, so it stops appearing in the UI. The existing comment notes that's a separate matter, since Jenkins scans that directory independently of JCasC.

Verified: every file now referenced by `jenkins.yml` exists in `jobs/`.

## What I couldn't check

**Whether the zombie job is actually executing, or erroring out immediately.** That needs the Jenkins UI — look at `pickipedia-enrich-torrents`' build history before assuming four months of this was harmless. If it has been succeeding, it's worth a glance at delivery-kid load and the bot's edit history too.

Found while adding the memory health check ([#99](https://github.com/cryptograss/maybelle-config/pull/99)); kept separate since it's an unrelated concern and may want to land faster.

https://claude.ai/code/session_015YGcYQ1UzPuNAxQhHTcCz6