### PR TITLE
chapter-1: stop reporting a failed deploy after a successful one

### DIFF
--- a/maybelle/scripts/maybelle-chapter-1.sh
+++ b/maybelle/scripts/maybelle-chapter-1.sh
@@ -102,8 +102,18 @@ echo ""
 
 # Commands to run on maybelle
 REMOTE_SCRIPT=$(cat <<'OUTER_EOF'
+#!/usr/bin/env bash
 set -e
-trap 'echo ""; echo "ERROR: Script failed at line $LINENO. Press enter to exit."; read' ERR
+# Pauses read from /dev/tty rather than inherited stdin. A bare `read` depends
+# on whatever stdin tmux hands the script; when that isn't a terminal it returns
+# non-zero at once, and with `set -e` the ERR trap below fires and announces a
+# failed deploy after a run that succeeded completely. `|| true` stops a pause
+# from ever being an error.
+#
+# `2>/dev/null` goes BEFORE `</dev/tty` on purpose. Redirections apply left to
+# right, so with the usual ordering bash reports a failed /dev/tty open using
+# the stderr it still has, and the message escapes anyway.
+trap 'echo ""; echo "ERROR: Script failed at line $LINENO. Press enter to exit."; read -r _ 2>/dev/null </dev/tty || true' ERR
 
 HETZNER_VOLUME_PATH="__HETZNER_VOLUME_PATH__"
 MOUNT_POINT="__MOUNT_POINT__"
@@ -175,7 +185,7 @@ echo ""
 echo "=== Chapter 1 complete ==="
 echo "Log saved to: $LOG_FILE"
 echo "Press enter to exit"
-read
+read -r _ 2>/dev/null </dev/tty || true
 OUTER_EOF
 )
 


### PR DESCRIPTION
```
PLAY RECAP *********************************************************************
localhost   : ok=111  changed=35  unreachable=0  failed=0  skipped=9

=== Chapter 1 complete ===
Log saved to: /tmp/ansible-deploy-20260807-213159.log
Press enter to exit

/tmp/chapter-1-script.sh: line 75: ead: command not found

ERROR: Script failed at line 75. Press enter to exit.
```

**Ansible succeeded** — `failed=0`. Everything after "Chapter 1 complete" is the wrapper's own exit pause going wrong, and it reads exactly like a failed deploy.

## What's happening

The generated remote script ends in a bare `read`, which takes whatever stdin tmux hands it. When that isn't a terminal, `read` returns non-zero immediately; `set -e` plus the `ERR` trap then announce a failure that didn't happen. The trap's own recovery was *also* a bare `read`, so a failing pause could re-enter the very trap reporting it.

I reproduced the false ERROR directly — the old form under a non-terminal stdin:

```
=== Chapter 1 complete ===
Press enter to exit

ERROR: Script failed at line 5. Press enter to exit.
```

Same shape as the real thing.

**One honest limit:** the `ead` fragment is consistent with the same stdin confusion consuming script bytes — the generated script is only 74 lines, so "line 75" is past its end — but I could not reproduce that exact split and I'm not claiming it as established. The false ERROR is the part that's demonstrated, and it's the part that matters.

## Changes

- **Pauses read from `/dev/tty`** rather than inherited stdin, so they work regardless of what stdin is, and end in `|| true` so a pause can never be an error.
- **`2>/dev/null` goes BEFORE `</dev/tty`.** Redirections apply left to right; with the natural ordering bash reports a failed `/dev/tty` open using the stderr it still has, and the message escapes anyway. I only caught this because I tested the no-terminal path instead of assuming.
- **Added a shebang.** The generated script was `chmod +x` and handed to tmux with no interpreter line.

## Verified

| case | before | after |
|---|---|---|
| no terminal | `ERROR: Script failed at line 5` | exits silently, status 0 |
| real terminal | pauses, then ERROR | pauses, exits clean |

Both the wrapper and the generated remote script pass `bash -n`.

## Why bother

A deploy tool that prints `ERROR: Script failed` after every successful run is how you learn to stop reading its output — which is roughly how the MCP server stayed down for five sessions.

https://claude.ai/code/session_015YGcYQ1UzPuNAxQhHTcCz6