### PR TITLE
maybelle: put health-check scripts where Jenkins can reach them

### DIFF
--- a/maybelle/ansible/maybelle.yml
+++ b/maybelle/ansible/maybelle.yml
@@ -138,6 +138,32 @@
         group: 1000
       notify: Restart Jenkins container
 
+    # Health-check scripts have to live inside the container. Only
+    # jenkins_home and a few log files are mounted — the maybelle-config
+    # checkout on the host is not — so a job pointing at
+    # /mnt/persist/maybelle-config/... resolves to nothing and the step dies
+    # with "not found". Copying them here mirrors how job .groovy files are
+    # already handled, and avoids mounting the whole config repo (vault
+    # included) into Jenkins just to reach two files.
+    - name: Create Jenkins scripts directory
+      file:
+        path: "{{ jenkins_home }}/scripts"
+        state: directory
+        mode: '0755'
+        owner: 1000
+        group: 1000
+
+    - name: Copy health-check scripts into Jenkins
+      copy:
+        src: "{{ item }}"
+        dest: "{{ jenkins_home }}/scripts/"
+        mode: '0755'
+        owner: 1000
+        group: 1000
+      loop:
+        - "{{ playbook_dir }}/../scripts/test-magenta-memory.py"
+        - "{{ playbook_dir }}/../../delivery-kid/scripts/test-delivery-kid.py"
+
     # `copy` doesn't delete files at dest that aren't in src, so removing a
     # .groovy from jobs/ leaves the old definition lingering. This task
     # ensures retired .groovy files don't get re-loaded on restart.

--- a/maybelle/jobs/delivery-kid-uptime.groovy
+++ b/maybelle/jobs/delivery-kid-uptime.groovy
@@ -26,7 +26,7 @@ pipelineJob('delivery-kid-uptime') {
                                 script {
                                     // Use the Python test script for comprehensive checks
                                     def result = sh(
-                                        script: '/mnt/persist/maybelle-config/delivery-kid/scripts/test-delivery-kid.py --json',
+                                        script: '/var/jenkins_home/scripts/test-delivery-kid.py --json',
                                         returnStdout: true
                                     ).trim()
 

--- a/maybelle/jobs/magenta-memory-uptime.groovy
+++ b/maybelle/jobs/magenta-memory-uptime.groovy
@@ -32,9 +32,18 @@ Exists because the MCP server went down and stayed down through four consecutive
                                     // JSON. Letting the non-zero exit throw here would
                                     // lose the per-check detail exactly when it matters.
                                     def result = sh(
-                                        script: '/mnt/persist/maybelle-config/maybelle/scripts/test-magenta-memory.py --json || true',
+                                        script: '/var/jenkins_home/scripts/test-magenta-memory.py --json || true',
                                         returnStdout: true
                                     ).trim()
+
+                                    // ...but `|| true` also swallows the script failing to
+                                    // run at all, and readJSON's complaint about empty text
+                                    // says nothing about why. Name that case before parsing.
+                                    if (!result) {
+                                        error("FAIL: health check produced no output — the script did not run. " +
+                                              "Expected it at /var/jenkins_home/scripts/test-magenta-memory.py; " +
+                                              "ansible copies it there from maybelle/scripts/.")
+                                    }
 
                                     def json = readJSON text: result
                                     echo "Checks passed: ${json.passed}/${json.total}"


### PR DESCRIPTION
`magenta-memory-uptime` loaded and ran — and failed every build:

```
/mnt/persist/maybelle-config/maybelle/scripts/test-magenta-memory.py: not found
readJSON: At least one of file or text needs to be provided
```

## Why

The Jenkins container mounts `jenkins_home` and a handful of log files. **It does not mount the maybelle-config checkout**, so any job pointing at `/mnt/persist/maybelle-config/...` is pointing at nothing. `python3` *is* in the image — the path was the whole problem.

I took that path from `delivery-kid-uptime.groovy`. That job has never been registered in JCasC and therefore **has never run**, so the pattern was never correct — just never exercised. Copying a convention from code that has never executed is the actual mistake here, and it's worth noting because there may be more of it about.

## Fix

- Both jobs now use `/var/jenkins_home/scripts/`.
- Ansible copies both health-check scripts there, mirroring how it already copies job `.groovy` files into `jenkins_home`.
- This also fixes `delivery-kid-uptime` for whenever it gets registered — it would have hit the identical wall.

**Copying rather than mounting the repo:** only two files are needed, and mounting the checkout would put `secrets/vault.yml` inside Jenkins to get them. The docker socket was deliberately removed from this container; widening the mount surface for two scripts cuts against that. Happy to switch to a read-only mount if you'd rather — it's a one-liner either way.

## Also: naming the failure

`|| true` is there so a failing health check still yields parseable JSON. But it equally swallows *the script not running at all*, and `readJSON`'s complaint about empty text says nothing about why. That's what made this take a round trip to diagnose. An empty result now errors with what was expected and where it should have come from.

## Verified

- `maybelle.yml` parses; both new tasks present
- No `/mnt/persist/maybelle-config` path left in any job definition
- Both source scripts exist and are executable at the paths ansible copies from

After deploy, `magenta-memory-uptime` should go from red-for-the-wrong-reason to red-for-the-right-reason — `memory_lane_heaps` is still genuinely broken, so expect **3/4 passing** until that's fixed separately.

https://claude.ai/code/session_015YGcYQ1UzPuNAxQhHTcCz6